### PR TITLE
feat: owner login, theme picker, nsite management

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,23 +9,30 @@
 		"preview": "vite preview",
 		"prepare": "svelte-kit sync || echo ''",
 		"check": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json",
-		"check:watch": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json --watch"
+		"check:watch": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json --watch",
+		"test": "vitest run"
 	},
 	"devDependencies": {
 		"@sveltejs/adapter-static": "^3.0.10",
 		"@sveltejs/kit": "^2.50.2",
 		"@sveltejs/vite-plugin-svelte": "^6.2.4",
 		"@tailwindcss/vite": "^4.2.1",
+		"@testing-library/jest-dom": "^6.9.1",
+		"@testing-library/svelte": "^5.3.1",
+		"jsdom": "^29.0.2",
 		"svelte": "^5.51.0",
 		"svelte-check": "^4.4.2",
 		"tailwindcss": "^4.2.1",
 		"typescript": "^5.9.3",
-		"vite": "^7.3.1"
+		"vite": "^7.3.1",
+		"vitest": "^4.1.4"
 	},
 	"dependencies": {
 		"applesauce-core": "^5.1.0",
 		"applesauce-relay": "^5.1.0",
+		"applesauce-signers": "5.2.0",
 		"@nsite/stealthis": "^0.2.0",
+		"lean-qr": "2.7.1",
 		"nostr-tools": "^2.23.3",
 		"rxjs": "^7.8.2"
 	}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -17,6 +17,12 @@ importers:
       applesauce-relay:
         specifier: ^5.1.0
         version: 5.1.0(typescript@5.9.3)
+      applesauce-signers:
+        specifier: 5.2.0
+        version: 5.2.0(@capacitor/core@7.6.1)(typescript@5.9.3)
+      lean-qr:
+        specifier: 2.7.1
+        version: 2.7.1
       nostr-tools:
         specifier: ^2.23.3
         version: 2.23.3(typescript@5.9.3)
@@ -36,6 +42,15 @@ importers:
       '@tailwindcss/vite':
         specifier: ^4.2.1
         version: 4.2.1(vite@7.3.1(jiti@2.6.1)(lightningcss@1.31.1))
+      '@testing-library/jest-dom':
+        specifier: ^6.9.1
+        version: 6.9.1
+      '@testing-library/svelte':
+        specifier: ^5.3.1
+        version: 5.3.1(svelte@5.53.7)(vite@7.3.1(jiti@2.6.1)(lightningcss@1.31.1))(vitest@4.1.4(jsdom@29.0.2(@noble/hashes@2.0.1))(vite@7.3.1(jiti@2.6.1)(lightningcss@1.31.1)))
+      jsdom:
+        specifier: ^29.0.2
+        version: 29.0.2(@noble/hashes@2.0.1)
       svelte:
         specifier: ^5.51.0
         version: 5.53.7
@@ -51,8 +66,80 @@ importers:
       vite:
         specifier: ^7.3.1
         version: 7.3.1(jiti@2.6.1)(lightningcss@1.31.1)
+      vitest:
+        specifier: ^4.1.4
+        version: 4.1.4(jsdom@29.0.2(@noble/hashes@2.0.1))(vite@7.3.1(jiti@2.6.1)(lightningcss@1.31.1))
 
 packages:
+
+  '@adobe/css-tools@4.4.4':
+    resolution: {integrity: sha512-Elp+iwUx5rN5+Y8xLt5/GRoG20WGoDCQ/1Fb+1LiGtvwbDavuSk0jhD/eZdckHAuzcDzccnkv+rEjyWfRx18gg==}
+
+  '@asamuzakjp/css-color@5.1.8':
+    resolution: {integrity: sha512-OISPR9c2uPo23rUdvfEQiLPjoMLOpEeLNnP5iGkxr6tDDxJd3NjD+6fxY0mdaMbIPUjFGL4HFOJqLvow5q4aqQ==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
+
+  '@asamuzakjp/dom-selector@7.0.9':
+    resolution: {integrity: sha512-r3ElRr7y8ucyN2KdICwGsmj19RoN13CLCa/pvGydghWK6ZzeKQ+TcDjVdtEZz2ElpndM5jXw//B9CEee0mWnVg==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
+
+  '@asamuzakjp/nwsapi@2.3.9':
+    resolution: {integrity: sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q==}
+
+  '@babel/code-frame@7.29.0':
+    resolution: {integrity: sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-validator-identifier@7.28.5':
+    resolution: {integrity: sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/runtime@7.29.2':
+    resolution: {integrity: sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g==}
+    engines: {node: '>=6.9.0'}
+
+  '@bramus/specificity@2.4.2':
+    resolution: {integrity: sha512-ctxtJ/eA+t+6q2++vj5j7FYX3nRu311q1wfYH3xjlLOsczhlhxAg2FWNUXhpGvAw3BWo1xBcvOV6/YLc2r5FJw==}
+    hasBin: true
+
+  '@capacitor/core@7.6.1':
+    resolution: {integrity: sha512-nsNouCMxgYenyemy20sZwZYMtFi93LSZVWm2KqHTYIPIDgwx24+PzwHIdRQBZdK7hpvD5jQEhWuo/QyLLnAyBQ==}
+
+  '@csstools/color-helpers@6.0.2':
+    resolution: {integrity: sha512-LMGQLS9EuADloEFkcTBR3BwV/CGHV7zyDxVRtVDTwdI2Ca4it0CCVTT9wCkxSgokjE5Ho41hEPgb8OEUwoXr6Q==}
+    engines: {node: '>=20.19.0'}
+
+  '@csstools/css-calc@3.1.1':
+    resolution: {integrity: sha512-HJ26Z/vmsZQqs/o3a6bgKslXGFAungXGbinULZO3eMsOyNJHeBBZfup5FiZInOghgoM4Hwnmw+OgbJCNg1wwUQ==}
+    engines: {node: '>=20.19.0'}
+    peerDependencies:
+      '@csstools/css-parser-algorithms': ^4.0.0
+      '@csstools/css-tokenizer': ^4.0.0
+
+  '@csstools/css-color-parser@4.0.2':
+    resolution: {integrity: sha512-0GEfbBLmTFf0dJlpsNU7zwxRIH0/BGEMuXLTCvFYxuL1tNhqzTbtnFICyJLTNK4a+RechKP75e7w42ClXSnJQw==}
+    engines: {node: '>=20.19.0'}
+    peerDependencies:
+      '@csstools/css-parser-algorithms': ^4.0.0
+      '@csstools/css-tokenizer': ^4.0.0
+
+  '@csstools/css-parser-algorithms@4.0.0':
+    resolution: {integrity: sha512-+B87qS7fIG3L5h3qwJ/IFbjoVoOe/bpOdh9hAjXbvx0o8ImEmUsGXN0inFOnk2ChCFgqkkGFQ+TpM5rbhkKe4w==}
+    engines: {node: '>=20.19.0'}
+    peerDependencies:
+      '@csstools/css-tokenizer': ^4.0.0
+
+  '@csstools/css-syntax-patches-for-csstree@1.1.2':
+    resolution: {integrity: sha512-5GkLzz4prTIpoyeUiIu3iV6CSG3Plo7xRVOFPKI7FVEJ3mZ0A8SwK0XU3Gl7xAkiQ+mDyam+NNp875/C5y+jSA==}
+    peerDependencies:
+      css-tree: ^3.2.1
+    peerDependenciesMeta:
+      css-tree:
+        optional: true
+
+  '@csstools/css-tokenizer@4.0.0':
+    resolution: {integrity: sha512-QxULHAm7cNu72w97JUNCBFODFaXpbDg+dP8b/oWFAZ2MTRppA3U00Y2L1HqaS4J6yBqxwa/Y3nMBaxVKbB/NsA==}
+    engines: {node: '>=20.19.0'}
 
   '@esbuild/aix-ppc64@0.27.3':
     resolution: {integrity: sha512-9fJMTNFTWZMh5qwrBItuziu834eOCUcEqymSH7pY+zoMVEZg3gcPuBNxH1EvfVYe9h0x/Ptw8KBzv7qxb7l8dg==}
@@ -210,6 +297,15 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  '@exodus/bytes@1.15.0':
+    resolution: {integrity: sha512-UY0nlA+feH81UGSHv92sLEPLCeZFjXOuHhrIo0HQydScuQc8s0A7kL/UdgwgDq8g8ilksmuoF35YVTNphV2aBQ==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
+    peerDependencies:
+      '@noble/hashes': ^1.8.0 || ^2.0.0
+    peerDependenciesMeta:
+      '@noble/hashes':
+        optional: true
+
   '@jridgewell/gen-mapping@0.3.13':
     resolution: {integrity: sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==}
 
@@ -258,6 +354,9 @@ packages:
   '@noble/hashes@2.0.1':
     resolution: {integrity: sha512-XlOlEbQcE9fmuXxrVTXCTlG2nlRXa9Rj3rr5Ue/+tX+nmkgbX720YHh0VR3hBF9xDvwnb8D2shVGOwNx+ulArw==}
     engines: {node: '>= 20.19.0'}
+
+  '@noble/secp256k1@1.7.2':
+    resolution: {integrity: sha512-/qzwYl5eFLH8OWIecQWM31qld2g1NfjgylK+TNhqtaUKP37Nm+Y+z30Fjhw0Ct8p9yCQEm2N3W/AckdIb3SMcQ==}
 
   '@nsite/stealthis@0.2.0':
     resolution: {integrity: sha512-iPjUferdyXFx1LLfgk1+upXAY5nH7vce1KsXNLBnO0t5+x6hdU9eZYyKVaZYkyBUMMcubJV64/QvBqqG03y/qQ==}
@@ -559,8 +658,44 @@ packages:
     peerDependencies:
       vite: ^5.2.0 || ^6 || ^7
 
+  '@testing-library/dom@10.4.1':
+    resolution: {integrity: sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==}
+    engines: {node: '>=18'}
+
+  '@testing-library/jest-dom@6.9.1':
+    resolution: {integrity: sha512-zIcONa+hVtVSSep9UT3jZ5rizo2BsxgyDYU7WFD5eICBE7no3881HGeb/QkGfsJs6JTkY1aQhT7rIPC7e+0nnA==}
+    engines: {node: '>=14', npm: '>=6', yarn: '>=1'}
+
+  '@testing-library/svelte-core@1.0.0':
+    resolution: {integrity: sha512-VkUePoLV6oOYwSUvX6ShA8KLnJqZiYMIbP2JW2t0GLWLkJxKGvuH5qrrZBV/X7cXFnLGuFQEC7RheYiZOW68KQ==}
+    engines: {node: '>=16'}
+    peerDependencies:
+      svelte: ^3 || ^4 || ^5 || ^5.0.0-next.0
+
+  '@testing-library/svelte@5.3.1':
+    resolution: {integrity: sha512-8Ez7ZOqW5geRf9PF5rkuopODe5RGy3I9XR+kc7zHh26gBiktLaxTfKmhlGaSHYUOTQE7wFsLMN9xCJVCszw47w==}
+    engines: {node: '>= 10'}
+    peerDependencies:
+      svelte: ^3 || ^4 || ^5 || ^5.0.0-next.0
+      vite: '*'
+      vitest: '*'
+    peerDependenciesMeta:
+      vite:
+        optional: true
+      vitest:
+        optional: true
+
+  '@types/aria-query@5.0.4':
+    resolution: {integrity: sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==}
+
+  '@types/chai@5.2.3':
+    resolution: {integrity: sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==}
+
   '@types/cookie@0.6.0':
     resolution: {integrity: sha512-4Kh9a6B2bQciAhf7FSuMRRkUWecJgJu9nPnx3yzpsfXX/c50REIqpHY4C82bXP90qrLtXtkDxTZosYO3UpOwlA==}
+
+  '@types/deep-eql@4.0.2':
+    resolution: {integrity: sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==}
 
   '@types/estree@1.0.8':
     resolution: {integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==}
@@ -568,24 +703,81 @@ packages:
   '@types/trusted-types@2.0.7':
     resolution: {integrity: sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==}
 
+  '@vitest/expect@4.1.4':
+    resolution: {integrity: sha512-iPBpra+VDuXmBFI3FMKHSFXp3Gx5HfmSCE8X67Dn+bwephCnQCaB7qWK2ldHa+8ncN8hJU8VTMcxjPpyMkUjww==}
+
+  '@vitest/mocker@4.1.4':
+    resolution: {integrity: sha512-R9HTZBhW6yCSGbGQnDnH3QHfJxokKN4KB+Yvk9Q1le7eQNYwiCyKxmLmurSpFy6BzJanSLuEUDrD+j97Q+ZLPg==}
+    peerDependencies:
+      msw: ^2.4.9
+      vite: ^6.0.0 || ^7.0.0 || ^8.0.0
+    peerDependenciesMeta:
+      msw:
+        optional: true
+      vite:
+        optional: true
+
+  '@vitest/pretty-format@4.1.4':
+    resolution: {integrity: sha512-ddmDHU0gjEUyEVLxtZa7xamrpIefdEETu3nZjWtHeZX4QxqJ7tRxSteHVXJOcr8jhiLoGAhkK4WJ3WqBpjx42A==}
+
+  '@vitest/runner@4.1.4':
+    resolution: {integrity: sha512-xTp7VZ5aXP5ZJrn15UtJUWlx6qXLnGtF6jNxHepdPHpMfz/aVPx+htHtgcAL2mDXJgKhpoo2e9/hVJsIeFbytQ==}
+
+  '@vitest/snapshot@4.1.4':
+    resolution: {integrity: sha512-MCjCFgaS8aZz+m5nTcEcgk/xhWv0rEH4Yl53PPlMXOZ1/Ka2VcZU6CJ+MgYCZbcJvzGhQRjVrGQNZqkGPttIKw==}
+
+  '@vitest/spy@4.1.4':
+    resolution: {integrity: sha512-XxNdAsKW7C+FLydqFJLb5KhJtl3PGCMmYwFRfhvIgxJvLSXhhVI1zM8f1qD3Zg7RCjTSzDVyct6sghs9UEgBEQ==}
+
+  '@vitest/utils@4.1.4':
+    resolution: {integrity: sha512-13QMT+eysM5uVGa1rG4kegGYNp6cnQcsTc67ELFbhNLQO+vgsygtYJx2khvdt4gVQqSSpC/KT5FZZxUpP3Oatw==}
+
   acorn@8.16.0:
     resolution: {integrity: sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==}
     engines: {node: '>=0.4.0'}
     hasBin: true
 
+  ansi-regex@5.0.1:
+    resolution: {integrity: sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==}
+    engines: {node: '>=8'}
+
+  ansi-styles@5.2.0:
+    resolution: {integrity: sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==}
+    engines: {node: '>=10'}
+
   applesauce-core@5.1.0:
     resolution: {integrity: sha512-kk4nHndK4zjS8Sa6mC8LGtQ0LDSP4hlCGPJ9lpyIln7MkZaNFWD9eFd+fsEhfE9kyrne9IyYuVfJNp+EqY1b9w==}
 
+  applesauce-core@5.2.0:
+    resolution: {integrity: sha512-aSuM6q6/Gs2FGUqytlHDjKZpSst2xKaT0vMXUQFWUctECNIxvwy6/hTDDInukMuI9mrQdjnO781ZJJgghI7RNw==}
+
   applesauce-relay@5.1.0:
     resolution: {integrity: sha512-d0LTJmQmr5gsYFm9A6efPEo2Bx/ewoL7LNsIdieMx34QohZBpPb137RvU9KQ1lFIXTm0tudd8VYfAPncqti2OQ==}
+
+  applesauce-signers@5.2.0:
+    resolution: {integrity: sha512-7tN7lNK2XERdrRchG5z4rdpMqOacFdv7rRhiS+DLTdlbqeSf0wD6Kj8M3vSqq5f2pVS2cl5Z4E/m5RpWC4PSxg==}
+
+  aria-query@5.3.0:
+    resolution: {integrity: sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==}
 
   aria-query@5.3.1:
     resolution: {integrity: sha512-Z/ZeOgVl7bcSYZ/u/rh0fOpvEpq//LZmdbkXyc7syVzjPAhfOa9ebsdTSjEBDU4vs5nC98Kfduj1uFo0qyET3g==}
     engines: {node: '>= 0.4'}
 
+  assertion-error@2.0.1:
+    resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
+    engines: {node: '>=12'}
+
   axobject-query@4.1.0:
     resolution: {integrity: sha512-qIj0G9wZbMGNLjLmg1PT6v2mE9AH2zlnADJD/2tC6E00hgmhUOfEB6greHPAfLRSufHqROIUTkw6E+M3lH0PTQ==}
     engines: {node: '>= 0.4'}
+
+  bidi-js@1.0.3:
+    resolution: {integrity: sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==}
+
+  chai@6.2.2:
+    resolution: {integrity: sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==}
+    engines: {node: '>=18'}
 
   chokidar@4.0.3:
     resolution: {integrity: sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==}
@@ -595,9 +787,23 @@ packages:
     resolution: {integrity: sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==}
     engines: {node: '>=6'}
 
+  convert-source-map@2.0.0:
+    resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
+
   cookie@0.6.0:
     resolution: {integrity: sha512-U71cyTamuh1CRNCfpGY6to28lxvNwPG4Guz/EVjgf3Jmzv0vlDp1atT9eS5dDjMYHucpHbWns6Lwf3BKz6svdw==}
     engines: {node: '>= 0.6'}
+
+  css-tree@3.2.1:
+    resolution: {integrity: sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==}
+    engines: {node: ^10 || ^12.20.0 || ^14.13.0 || >=15.0.0}
+
+  css.escape@1.5.1:
+    resolution: {integrity: sha512-YUifsXXuknHlUsmlgyY0PKzgPOr7/FjCePfHNt0jxm83wHZi44VDMQ7/fGNkjY3/jV1MC+1CmZbaHzugyeRtpg==}
+
+  data-urls@7.0.0:
+    resolution: {integrity: sha512-23XHcCF+coGYevirZceTVD7NdJOqVn+49IHyxgszm+JIiHLoB2TkmPtsYkNWT1pvRSGkc35L6NHs0yHkN2SumA==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
 
   debug@4.4.3:
     resolution: {integrity: sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==}
@@ -608,9 +814,16 @@ packages:
       supports-color:
         optional: true
 
+  decimal.js@10.6.0:
+    resolution: {integrity: sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==}
+
   deepmerge@4.3.1:
     resolution: {integrity: sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A==}
     engines: {node: '>=0.10.0'}
+
+  dequal@2.0.3:
+    resolution: {integrity: sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==}
+    engines: {node: '>=6'}
 
   detect-libc@2.1.2:
     resolution: {integrity: sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==}
@@ -619,9 +832,22 @@ packages:
   devalue@5.6.3:
     resolution: {integrity: sha512-nc7XjUU/2Lb+SvEFVGcWLiKkzfw8+qHI7zn8WYXKkLMgfGSHbgCEaR6bJpev8Cm6Rmrb19Gfd/tZvGqx9is3wg==}
 
+  dom-accessibility-api@0.5.16:
+    resolution: {integrity: sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==}
+
+  dom-accessibility-api@0.6.3:
+    resolution: {integrity: sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w==}
+
   enhanced-resolve@5.20.0:
     resolution: {integrity: sha512-/ce7+jQ1PQ6rVXwe+jKEg5hW5ciicHwIQUagZkp6IufBoY3YDgdTTY1azVs0qoRgVmvsNB+rbjLJxDAeHHtwsQ==}
     engines: {node: '>=10.13.0'}
+
+  entities@6.0.1:
+    resolution: {integrity: sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==}
+    engines: {node: '>=0.12'}
+
+  es-module-lexer@2.0.0:
+    resolution: {integrity: sha512-5POEcUuZybH7IdmGsD8wlf0AI55wMecM9rVBTI/qEAy2c1kTOm3DjFYjrBdI2K3BaJjJYfYFeRtM0t9ssnRuxw==}
 
   esbuild@0.27.3:
     resolution: {integrity: sha512-8VwMnyGCONIs6cWue2IdpHxHnAjzxnw2Zr7MkVxB2vjmQ2ivqGFb4LEG3SMnv0Gb2F/G/2yA8zUaiL1gywDCCg==}
@@ -633,6 +859,13 @@ packages:
 
   esrap@2.2.3:
     resolution: {integrity: sha512-8fOS+GIGCQZl/ZIlhl59htOlms6U8NvX6ZYgYHpRU/b6tVSh3uHkOHZikl3D4cMbYM0JlpBe+p/BkZEi8J9XIQ==}
+
+  estree-walker@3.0.3:
+    resolution: {integrity: sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==}
+
+  expect-type@1.3.0:
+    resolution: {integrity: sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==}
+    engines: {node: '>=12.0.0'}
 
   fast-deep-equal@3.1.3:
     resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
@@ -657,6 +890,17 @@ packages:
   hash-sum@2.0.0:
     resolution: {integrity: sha512-WdZTbAByD+pHfl/g9QSsBIIwy8IT+EsPiKDs0KNX+zSHhdDLFKdZu0BQHljvO+0QI/BasbMSUa8wYNCZTvhslg==}
 
+  html-encoding-sniffer@6.0.0:
+    resolution: {integrity: sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
+
+  indent-string@4.0.0:
+    resolution: {integrity: sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==}
+    engines: {node: '>=8'}
+
+  is-potential-custom-element-name@1.0.1:
+    resolution: {integrity: sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==}
+
   is-reference@3.0.3:
     resolution: {integrity: sha512-ixkJoqQvAP88E6wLydLGGqCJsrFUnqoH6HnaczB8XmDH1oaWU+xxdptvikTgaEhtZ53Ky6YXiBuUI2WXLMCwjw==}
 
@@ -664,9 +908,25 @@ packages:
     resolution: {integrity: sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ==}
     hasBin: true
 
+  js-tokens@4.0.0:
+    resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
+
+  jsdom@29.0.2:
+    resolution: {integrity: sha512-9VnGEBosc/ZpwyOsJBCQ/3I5p7Q5ngOY14a9bf5btenAORmZfDse1ZEheMiWcJ3h81+Fv7HmJFdS0szo/waF2w==}
+    engines: {node: ^20.19.0 || ^22.13.0 || >=24.0.0}
+    peerDependencies:
+      canvas: ^3.0.0
+    peerDependenciesMeta:
+      canvas:
+        optional: true
+
   kleur@4.1.5:
     resolution: {integrity: sha512-o+NO+8WrRiQEE4/7nwRJhN1HWpVmJm511pBHUxPLtp0BUISzlBplORYSmTclCnJvQq2tKu/sgl3xVpkc7ZWuQQ==}
     engines: {node: '>=6'}
+
+  lean-qr@2.7.1:
+    resolution: {integrity: sha512-4WfYs9t1jpiF6nDRxe9LFlWzRhvVeiV3tpsjAkrijHx5dtrF0E4dupvjJX3SUoS18CAaU6QF2gSZILO10z8utA==}
+    hasBin: true
 
   lightningcss-android-arm64@1.31.1:
     resolution: {integrity: sha512-HXJF3x8w9nQ4jbXRiNppBCqeZPIAfUo8zE/kOEGbW5NZvGc/K7nMxbhIr+YlFlHW5mpbg/YFPdbnCh1wAXCKFg==}
@@ -745,8 +1005,23 @@ packages:
   locate-character@3.0.0:
     resolution: {integrity: sha512-SW13ws7BjaeJ6p7Q6CO2nchbYEc3X3J6WrmTTDto7yMPqVSZTUyY5Tjbid+Ab8gLnATtygYtiDIJGQRRn2ZOiA==}
 
+  lru-cache@11.3.3:
+    resolution: {integrity: sha512-JvNw9Y81y33E+BEYPr0U7omo+U9AySnsMsEiXgwT6yqd31VQWTLNQqmT4ou5eqPFUrTfIDFta2wKhB1hyohtAQ==}
+    engines: {node: 20 || >=22}
+
+  lz-string@1.5.0:
+    resolution: {integrity: sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==}
+    hasBin: true
+
   magic-string@0.30.21:
     resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
+
+  mdn-data@2.27.1:
+    resolution: {integrity: sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==}
+
+  min-indent@1.0.1:
+    resolution: {integrity: sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==}
+    engines: {node: '>=4'}
 
   mri@1.2.0:
     resolution: {integrity: sha512-tzzskb3bG8LvYGFF/mDTpq3jpI6Q9wc3LEmBaghu+DdCssd1FakN7Bc0hVNmEyGq1bq3RgfkCb3cmQLpNPOroA==}
@@ -768,6 +1043,11 @@ packages:
     resolution: {integrity: sha512-c7+7RQ+dMB5dPwwCp4ee1/iV/q2P6aK1mTZcfr1BTuVlyW9hJYiMPybJCcnBlQtuSmTIWNeazm/zqNoZSSElBg==}
     engines: {node: ^18 || >=20}
     hasBin: true
+
+  nostr-signer-capacitor-plugin@0.0.5:
+    resolution: {integrity: sha512-/EvqWz71HZ5cWmzvfXWTm48AWZtbeZDbOg3vLwXyXPjnIp1DR7Wurww/Mo41ORNu1DNPlqH20l7kIXKO6vR5og==}
+    peerDependencies:
+      '@capacitor/core': ^7.0.0
 
   nostr-tools@2.19.4:
     resolution: {integrity: sha512-qVLfoTpZegNYRJo5j+Oi6RPu0AwLP6jcvzcB3ySMnIT5DrAGNXfs5HNBspB/2HiGfH3GY+v6yXkTtcKSBQZwSg==}
@@ -791,6 +1071,12 @@ packages:
   obug@2.1.1:
     resolution: {integrity: sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==}
 
+  parse5@8.0.0:
+    resolution: {integrity: sha512-9m4m5GSgXjL4AjumKzq1Fgfp3Z8rsvjRNbnkVwfu2ImRqE5D0LnY2QfDen18FSY9C573YU5XxSapdHZTZ2WolA==}
+
+  pathe@2.0.3:
+    resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
+
   picocolors@1.1.1:
     resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
 
@@ -802,12 +1088,31 @@ packages:
     resolution: {integrity: sha512-OW/rX8O/jXnm82Ey1k44pObPtdblfiuWnrd8X7GJ7emImCOstunGbXUpp7HdBrFQX6rJzn3sPT397Wp5aCwCHg==}
     engines: {node: ^10 || ^12 || >=14}
 
+  pretty-format@27.5.1:
+    resolution: {integrity: sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==}
+    engines: {node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0}
+
+  punycode@2.3.1:
+    resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
+    engines: {node: '>=6'}
+
   qrcode-generator@1.5.2:
     resolution: {integrity: sha512-pItrW0Z9HnDBnFmgiNrY1uxRdri32Uh9EjNYLPVC2zZ3ZRIIEqBoDgm4DkvDwNNDHTK7FNkmr8zAa77BYc9xNw==}
+
+  react-is@17.0.2:
+    resolution: {integrity: sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==}
 
   readdirp@4.1.2:
     resolution: {integrity: sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==}
     engines: {node: '>= 14.18.0'}
+
+  redent@3.0.0:
+    resolution: {integrity: sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==}
+    engines: {node: '>=8'}
+
+  require-from-string@2.0.2:
+    resolution: {integrity: sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==}
+    engines: {node: '>=0.10.0'}
 
   rollup@4.59.0:
     resolution: {integrity: sha512-2oMpl67a3zCH9H79LeMcbDhXW/UmWG/y2zuqnF2jQq5uq9TbM9TVyXvA4+t+ne2IIkBdrLpAaRQAvo7YI/Yyeg==}
@@ -821,8 +1126,15 @@ packages:
     resolution: {integrity: sha512-xal3CZX1Xlo/k4ApwCFrHVACi9fBqJ7V+mwhBsuf/1IOKbBy098Fex+Wa/5QMubw09pSZ/u8EY8PWgevJsXp1A==}
     engines: {node: '>=6'}
 
+  saxes@6.0.0:
+    resolution: {integrity: sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==}
+    engines: {node: '>=v12.22.7'}
+
   set-cookie-parser@3.0.1:
     resolution: {integrity: sha512-n7Z7dXZhJbwuAHhNzkTti6Aw9QDDjZtm3JTpTGATIdNzdQz5GuFs22w90BcvF4INfnrL5xrX3oGsuqO5Dx3A1Q==}
+
+  siginfo@2.0.0:
+    resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
 
   sirv@3.0.2:
     resolution: {integrity: sha512-2wcC/oGxHis/BoHkkPwldgiPSYcpZK3JU28WoMVv55yHJgcZ8rlXvuG9iZggz+sU1d4bRgIGASwyWqjxu3FM0g==}
@@ -831,6 +1143,16 @@ packages:
   source-map-js@1.2.1:
     resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
     engines: {node: '>=0.10.0'}
+
+  stackback@0.0.2:
+    resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
+
+  std-env@4.0.0:
+    resolution: {integrity: sha512-zUMPtQ/HBY3/50VbpkupYHbRroTRZJPRLvreamgErJVys0ceuzMkD44J/QjqhHjOzK42GQ3QZIeFG1OYfOtKqQ==}
+
+  strip-indent@3.0.0:
+    resolution: {integrity: sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==}
+    engines: {node: '>=8'}
 
   svelte-check@4.4.4:
     resolution: {integrity: sha512-F1pGqXc710Oi/wTI4d/x7d6lgPwwfx1U6w3Q35n4xsC2e8C/yN2sM1+mWxjlMcpAfWucjlq4vPi+P4FZ8a14sQ==}
@@ -844,6 +1166,9 @@ packages:
     resolution: {integrity: sha512-uxck1KI7JWtlfP3H6HOWi/94soAl23jsGJkBzN2BAWcQng0+lTrRNhxActFqORgnO9BHVd1hKJhG+ljRuIUWfQ==}
     engines: {node: '>=18'}
 
+  symbol-tree@3.2.4:
+    resolution: {integrity: sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==}
+
   tailwindcss@4.2.1:
     resolution: {integrity: sha512-/tBrSQ36vCleJkAOsy9kbNTgaxvGbyOamC30PRePTQe/o1MFwEKHQk4Cn7BNGaPtjp+PuUrByJehM1hgxfq4sw==}
 
@@ -851,13 +1176,39 @@ packages:
     resolution: {integrity: sha512-g9ljZiwki/LfxmQADO3dEY1CbpmXT5Hm2fJ+QaGKwSXUylMybePR7/67YW7jOrrvjEgL1Fmz5kzyAjWVWLlucg==}
     engines: {node: '>=6'}
 
+  tinybench@2.9.0:
+    resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
+
+  tinyexec@1.1.1:
+    resolution: {integrity: sha512-VKS/ZaQhhkKFMANmAOhhXVoIfBXblQxGX1myCQ2faQrfmobMftXeJPcZGp0gS07ocvGJWDLZGyOZDadDBqYIJg==}
+    engines: {node: '>=18'}
+
   tinyglobby@0.2.15:
     resolution: {integrity: sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==}
     engines: {node: '>=12.0.0'}
 
+  tinyrainbow@3.1.0:
+    resolution: {integrity: sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==}
+    engines: {node: '>=14.0.0'}
+
+  tldts-core@7.0.28:
+    resolution: {integrity: sha512-7W5Efjhsc3chVdFhqtaU0KtK32J37Zcr9RKtID54nG+tIpcY79CQK/veYPODxtD/LJ4Lue66jvrQzIX2Z2/pUQ==}
+
+  tldts@7.0.28:
+    resolution: {integrity: sha512-+Zg3vWhRUv8B1maGSTFdev9mjoo8Etn2Ayfs4cnjlD3CsGkxXX4QyW3j2WJ0wdjYcYmy7Lx2RDsZMhgCWafKIw==}
+    hasBin: true
+
   totalist@3.0.1:
     resolution: {integrity: sha512-sf4i37nQ2LBx4m3wB74y+ubopq6W/dIzXg0FDGjsYnZHVa1Da8FH853wlL2gtUhg+xJXjfk3kUZS3BRoQeoQBQ==}
     engines: {node: '>=6'}
+
+  tough-cookie@6.0.1:
+    resolution: {integrity: sha512-LktZQb3IeoUWB9lqR5EWTHgW/VTITCXg4D21M+lvybRVdylLrRMnqaIONLVb5mav8vM19m44HIcGq4qASeu2Qw==}
+    engines: {node: '>=16'}
+
+  tr46@6.0.0:
+    resolution: {integrity: sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==}
+    engines: {node: '>=20'}
 
   tslib@2.8.1:
     resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
@@ -866,6 +1217,10 @@ packages:
     resolution: {integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==}
     engines: {node: '>=14.17'}
     hasBin: true
+
+  undici@7.24.7:
+    resolution: {integrity: sha512-H/nlJ/h0ggGC+uRL3ovD+G0i4bqhvsDOpbDv7At5eFLlj2b41L8QliGbnl2H7SnDiYhENphh1tQFJZf+MyfLsQ==}
+    engines: {node: '>=20.18.1'}
 
   vite@7.3.1:
     resolution: {integrity: sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==}
@@ -915,10 +1270,140 @@ packages:
       vite:
         optional: true
 
+  vitest@4.1.4:
+    resolution: {integrity: sha512-tFuJqTxKb8AvfyqMfnavXdzfy3h3sWZRWwfluGbkeR7n0HUev+FmNgZ8SDrRBTVrVCjgH5cA21qGbCffMNtWvg==}
+    engines: {node: ^20.0.0 || ^22.0.0 || >=24.0.0}
+    hasBin: true
+    peerDependencies:
+      '@edge-runtime/vm': '*'
+      '@opentelemetry/api': ^1.9.0
+      '@types/node': ^20.0.0 || ^22.0.0 || >=24.0.0
+      '@vitest/browser-playwright': 4.1.4
+      '@vitest/browser-preview': 4.1.4
+      '@vitest/browser-webdriverio': 4.1.4
+      '@vitest/coverage-istanbul': 4.1.4
+      '@vitest/coverage-v8': 4.1.4
+      '@vitest/ui': 4.1.4
+      happy-dom: '*'
+      jsdom: '*'
+      vite: ^6.0.0 || ^7.0.0 || ^8.0.0
+    peerDependenciesMeta:
+      '@edge-runtime/vm':
+        optional: true
+      '@opentelemetry/api':
+        optional: true
+      '@types/node':
+        optional: true
+      '@vitest/browser-playwright':
+        optional: true
+      '@vitest/browser-preview':
+        optional: true
+      '@vitest/browser-webdriverio':
+        optional: true
+      '@vitest/coverage-istanbul':
+        optional: true
+      '@vitest/coverage-v8':
+        optional: true
+      '@vitest/ui':
+        optional: true
+      happy-dom:
+        optional: true
+      jsdom:
+        optional: true
+
+  w3c-xmlserializer@5.0.0:
+    resolution: {integrity: sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==}
+    engines: {node: '>=18'}
+
+  webidl-conversions@8.0.1:
+    resolution: {integrity: sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ==}
+    engines: {node: '>=20'}
+
+  whatwg-mimetype@5.0.0:
+    resolution: {integrity: sha512-sXcNcHOC51uPGF0P/D4NVtrkjSU2fNsm9iog4ZvZJsL3rjoDAzXZhkm2MWt1y+PUdggKAYVoMAIYcs78wJ51Cw==}
+    engines: {node: '>=20'}
+
+  whatwg-url@16.0.1:
+    resolution: {integrity: sha512-1to4zXBxmXHV3IiSSEInrreIlu02vUOvrhxJJH5vcxYTBDAx51cqZiKdyTxlecdKNSjj8EcxGBxNf6Vg+945gw==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
+
+  why-is-node-running@2.3.0:
+    resolution: {integrity: sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==}
+    engines: {node: '>=8'}
+    hasBin: true
+
+  xml-name-validator@5.0.0:
+    resolution: {integrity: sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==}
+    engines: {node: '>=18'}
+
+  xmlchars@2.2.0:
+    resolution: {integrity: sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==}
+
   zimmerframe@1.1.4:
     resolution: {integrity: sha512-B58NGBEoc8Y9MWWCQGl/gq9xBCe4IiKM0a2x7GZdQKOW5Exr8S1W24J6OgM1njK8xCRGvAJIL/MxXHf6SkmQKQ==}
 
 snapshots:
+
+  '@adobe/css-tools@4.4.4': {}
+
+  '@asamuzakjp/css-color@5.1.8':
+    dependencies:
+      '@csstools/css-calc': 3.1.1(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-color-parser': 4.0.2(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-parser-algorithms': 4.0.0(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-tokenizer': 4.0.0
+
+  '@asamuzakjp/dom-selector@7.0.9':
+    dependencies:
+      '@asamuzakjp/nwsapi': 2.3.9
+      bidi-js: 1.0.3
+      css-tree: 3.2.1
+      is-potential-custom-element-name: 1.0.1
+
+  '@asamuzakjp/nwsapi@2.3.9': {}
+
+  '@babel/code-frame@7.29.0':
+    dependencies:
+      '@babel/helper-validator-identifier': 7.28.5
+      js-tokens: 4.0.0
+      picocolors: 1.1.1
+
+  '@babel/helper-validator-identifier@7.28.5': {}
+
+  '@babel/runtime@7.29.2': {}
+
+  '@bramus/specificity@2.4.2':
+    dependencies:
+      css-tree: 3.2.1
+
+  '@capacitor/core@7.6.1':
+    dependencies:
+      tslib: 2.8.1
+    optional: true
+
+  '@csstools/color-helpers@6.0.2': {}
+
+  '@csstools/css-calc@3.1.1(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)':
+    dependencies:
+      '@csstools/css-parser-algorithms': 4.0.0(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-tokenizer': 4.0.0
+
+  '@csstools/css-color-parser@4.0.2(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)':
+    dependencies:
+      '@csstools/color-helpers': 6.0.2
+      '@csstools/css-calc': 3.1.1(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-parser-algorithms': 4.0.0(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-tokenizer': 4.0.0
+
+  '@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0)':
+    dependencies:
+      '@csstools/css-tokenizer': 4.0.0
+
+  '@csstools/css-syntax-patches-for-csstree@1.1.2(css-tree@3.2.1)':
+    optionalDependencies:
+      css-tree: 3.2.1
+
+  '@csstools/css-tokenizer@4.0.0': {}
 
   '@esbuild/aix-ppc64@0.27.3':
     optional: true
@@ -998,6 +1483,10 @@ snapshots:
   '@esbuild/win32-x64@0.27.3':
     optional: true
 
+  '@exodus/bytes@1.15.0(@noble/hashes@2.0.1)':
+    optionalDependencies:
+      '@noble/hashes': 2.0.1
+
   '@jridgewell/gen-mapping@0.3.13':
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
@@ -1040,6 +1529,8 @@ snapshots:
   '@noble/hashes@1.8.0': {}
 
   '@noble/hashes@2.0.1': {}
+
+  '@noble/secp256k1@1.7.2': {}
 
   '@nsite/stealthis@0.2.0(typescript@5.9.3)':
     dependencies:
@@ -1266,15 +1757,114 @@ snapshots:
       tailwindcss: 4.2.1
       vite: 7.3.1(jiti@2.6.1)(lightningcss@1.31.1)
 
+  '@testing-library/dom@10.4.1':
+    dependencies:
+      '@babel/code-frame': 7.29.0
+      '@babel/runtime': 7.29.2
+      '@types/aria-query': 5.0.4
+      aria-query: 5.3.0
+      dom-accessibility-api: 0.5.16
+      lz-string: 1.5.0
+      picocolors: 1.1.1
+      pretty-format: 27.5.1
+
+  '@testing-library/jest-dom@6.9.1':
+    dependencies:
+      '@adobe/css-tools': 4.4.4
+      aria-query: 5.3.1
+      css.escape: 1.5.1
+      dom-accessibility-api: 0.6.3
+      picocolors: 1.1.1
+      redent: 3.0.0
+
+  '@testing-library/svelte-core@1.0.0(svelte@5.53.7)':
+    dependencies:
+      svelte: 5.53.7
+
+  '@testing-library/svelte@5.3.1(svelte@5.53.7)(vite@7.3.1(jiti@2.6.1)(lightningcss@1.31.1))(vitest@4.1.4(jsdom@29.0.2(@noble/hashes@2.0.1))(vite@7.3.1(jiti@2.6.1)(lightningcss@1.31.1)))':
+    dependencies:
+      '@testing-library/dom': 10.4.1
+      '@testing-library/svelte-core': 1.0.0(svelte@5.53.7)
+      svelte: 5.53.7
+    optionalDependencies:
+      vite: 7.3.1(jiti@2.6.1)(lightningcss@1.31.1)
+      vitest: 4.1.4(jsdom@29.0.2(@noble/hashes@2.0.1))(vite@7.3.1(jiti@2.6.1)(lightningcss@1.31.1))
+
+  '@types/aria-query@5.0.4': {}
+
+  '@types/chai@5.2.3':
+    dependencies:
+      '@types/deep-eql': 4.0.2
+      assertion-error: 2.0.1
+
   '@types/cookie@0.6.0': {}
+
+  '@types/deep-eql@4.0.2': {}
 
   '@types/estree@1.0.8': {}
 
   '@types/trusted-types@2.0.7': {}
 
+  '@vitest/expect@4.1.4':
+    dependencies:
+      '@standard-schema/spec': 1.1.0
+      '@types/chai': 5.2.3
+      '@vitest/spy': 4.1.4
+      '@vitest/utils': 4.1.4
+      chai: 6.2.2
+      tinyrainbow: 3.1.0
+
+  '@vitest/mocker@4.1.4(vite@7.3.1(jiti@2.6.1)(lightningcss@1.31.1))':
+    dependencies:
+      '@vitest/spy': 4.1.4
+      estree-walker: 3.0.3
+      magic-string: 0.30.21
+    optionalDependencies:
+      vite: 7.3.1(jiti@2.6.1)(lightningcss@1.31.1)
+
+  '@vitest/pretty-format@4.1.4':
+    dependencies:
+      tinyrainbow: 3.1.0
+
+  '@vitest/runner@4.1.4':
+    dependencies:
+      '@vitest/utils': 4.1.4
+      pathe: 2.0.3
+
+  '@vitest/snapshot@4.1.4':
+    dependencies:
+      '@vitest/pretty-format': 4.1.4
+      '@vitest/utils': 4.1.4
+      magic-string: 0.30.21
+      pathe: 2.0.3
+
+  '@vitest/spy@4.1.4': {}
+
+  '@vitest/utils@4.1.4':
+    dependencies:
+      '@vitest/pretty-format': 4.1.4
+      convert-source-map: 2.0.0
+      tinyrainbow: 3.1.0
+
   acorn@8.16.0: {}
 
+  ansi-regex@5.0.1: {}
+
+  ansi-styles@5.2.0: {}
+
   applesauce-core@5.1.0(typescript@5.9.3):
+    dependencies:
+      debug: 4.4.3
+      fast-deep-equal: 3.1.3
+      hash-sum: 2.0.0
+      nanoid: 5.1.6
+      nostr-tools: 2.19.4(typescript@5.9.3)
+      rxjs: 7.8.2
+    transitivePeerDependencies:
+      - supports-color
+      - typescript
+
+  applesauce-core@5.2.0(typescript@5.9.3):
     dependencies:
       debug: 4.4.3
       fast-deep-equal: 3.1.3
@@ -1297,9 +1887,35 @@ snapshots:
       - supports-color
       - typescript
 
+  applesauce-signers@5.2.0(@capacitor/core@7.6.1)(typescript@5.9.3):
+    dependencies:
+      '@noble/secp256k1': 1.7.2
+      applesauce-core: 5.2.0(typescript@5.9.3)
+      debug: 4.4.3
+      nanoid: 5.1.6
+      rxjs: 7.8.2
+    optionalDependencies:
+      nostr-signer-capacitor-plugin: 0.0.5(@capacitor/core@7.6.1)
+    transitivePeerDependencies:
+      - '@capacitor/core'
+      - supports-color
+      - typescript
+
+  aria-query@5.3.0:
+    dependencies:
+      dequal: 2.0.3
+
   aria-query@5.3.1: {}
 
+  assertion-error@2.0.1: {}
+
   axobject-query@4.1.0: {}
+
+  bidi-js@1.0.3:
+    dependencies:
+      require-from-string: 2.0.2
+
+  chai@6.2.2: {}
 
   chokidar@4.0.3:
     dependencies:
@@ -1307,22 +1923,50 @@ snapshots:
 
   clsx@2.1.1: {}
 
+  convert-source-map@2.0.0: {}
+
   cookie@0.6.0: {}
+
+  css-tree@3.2.1:
+    dependencies:
+      mdn-data: 2.27.1
+      source-map-js: 1.2.1
+
+  css.escape@1.5.1: {}
+
+  data-urls@7.0.0(@noble/hashes@2.0.1):
+    dependencies:
+      whatwg-mimetype: 5.0.0
+      whatwg-url: 16.0.1(@noble/hashes@2.0.1)
+    transitivePeerDependencies:
+      - '@noble/hashes'
 
   debug@4.4.3:
     dependencies:
       ms: 2.1.3
 
+  decimal.js@10.6.0: {}
+
   deepmerge@4.3.1: {}
+
+  dequal@2.0.3: {}
 
   detect-libc@2.1.2: {}
 
   devalue@5.6.3: {}
 
+  dom-accessibility-api@0.5.16: {}
+
+  dom-accessibility-api@0.6.3: {}
+
   enhanced-resolve@5.20.0:
     dependencies:
       graceful-fs: 4.2.11
       tapable: 2.3.0
+
+  entities@6.0.1: {}
+
+  es-module-lexer@2.0.0: {}
 
   esbuild@0.27.3:
     optionalDependencies:
@@ -1359,6 +2003,12 @@ snapshots:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
 
+  estree-walker@3.0.3:
+    dependencies:
+      '@types/estree': 1.0.8
+
+  expect-type@1.3.0: {}
+
   fast-deep-equal@3.1.3: {}
 
   fdir@6.5.0(picomatch@4.0.3):
@@ -1372,13 +2022,53 @@ snapshots:
 
   hash-sum@2.0.0: {}
 
+  html-encoding-sniffer@6.0.0(@noble/hashes@2.0.1):
+    dependencies:
+      '@exodus/bytes': 1.15.0(@noble/hashes@2.0.1)
+    transitivePeerDependencies:
+      - '@noble/hashes'
+
+  indent-string@4.0.0: {}
+
+  is-potential-custom-element-name@1.0.1: {}
+
   is-reference@3.0.3:
     dependencies:
       '@types/estree': 1.0.8
 
   jiti@2.6.1: {}
 
+  js-tokens@4.0.0: {}
+
+  jsdom@29.0.2(@noble/hashes@2.0.1):
+    dependencies:
+      '@asamuzakjp/css-color': 5.1.8
+      '@asamuzakjp/dom-selector': 7.0.9
+      '@bramus/specificity': 2.4.2
+      '@csstools/css-syntax-patches-for-csstree': 1.1.2(css-tree@3.2.1)
+      '@exodus/bytes': 1.15.0(@noble/hashes@2.0.1)
+      css-tree: 3.2.1
+      data-urls: 7.0.0(@noble/hashes@2.0.1)
+      decimal.js: 10.6.0
+      html-encoding-sniffer: 6.0.0(@noble/hashes@2.0.1)
+      is-potential-custom-element-name: 1.0.1
+      lru-cache: 11.3.3
+      parse5: 8.0.0
+      saxes: 6.0.0
+      symbol-tree: 3.2.4
+      tough-cookie: 6.0.1
+      undici: 7.24.7
+      w3c-xmlserializer: 5.0.0
+      webidl-conversions: 8.0.1
+      whatwg-mimetype: 5.0.0
+      whatwg-url: 16.0.1(@noble/hashes@2.0.1)
+      xml-name-validator: 5.0.0
+    transitivePeerDependencies:
+      - '@noble/hashes'
+
   kleur@4.1.5: {}
+
+  lean-qr@2.7.1: {}
 
   lightningcss-android-arm64@1.31.1:
     optional: true
@@ -1431,9 +2121,17 @@ snapshots:
 
   locate-character@3.0.0: {}
 
+  lru-cache@11.3.3: {}
+
+  lz-string@1.5.0: {}
+
   magic-string@0.30.21:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
+
+  mdn-data@2.27.1: {}
+
+  min-indent@1.0.1: {}
 
   mri@1.2.0: {}
 
@@ -1444,6 +2142,11 @@ snapshots:
   nanoid@3.3.11: {}
 
   nanoid@5.1.6: {}
+
+  nostr-signer-capacitor-plugin@0.0.5(@capacitor/core@7.6.1):
+    dependencies:
+      '@capacitor/core': 7.6.1
+    optional: true
 
   nostr-tools@2.19.4(typescript@5.9.3):
     dependencies:
@@ -1473,6 +2176,12 @@ snapshots:
 
   obug@2.1.1: {}
 
+  parse5@8.0.0:
+    dependencies:
+      entities: 6.0.1
+
+  pathe@2.0.3: {}
+
   picocolors@1.1.1: {}
 
   picomatch@4.0.3: {}
@@ -1483,9 +2192,26 @@ snapshots:
       picocolors: 1.1.1
       source-map-js: 1.2.1
 
+  pretty-format@27.5.1:
+    dependencies:
+      ansi-regex: 5.0.1
+      ansi-styles: 5.2.0
+      react-is: 17.0.2
+
+  punycode@2.3.1: {}
+
   qrcode-generator@1.5.2: {}
 
+  react-is@17.0.2: {}
+
   readdirp@4.1.2: {}
+
+  redent@3.0.0:
+    dependencies:
+      indent-string: 4.0.0
+      strip-indent: 3.0.0
+
+  require-from-string@2.0.2: {}
 
   rollup@4.59.0:
     dependencies:
@@ -1526,7 +2252,13 @@ snapshots:
     dependencies:
       mri: 1.2.0
 
+  saxes@6.0.0:
+    dependencies:
+      xmlchars: 2.2.0
+
   set-cookie-parser@3.0.1: {}
+
+  siginfo@2.0.0: {}
 
   sirv@3.0.2:
     dependencies:
@@ -1535,6 +2267,14 @@ snapshots:
       totalist: 3.0.1
 
   source-map-js@1.2.1: {}
+
+  stackback@0.0.2: {}
+
+  std-env@4.0.0: {}
+
+  strip-indent@3.0.0:
+    dependencies:
+      min-indent: 1.0.1
 
   svelte-check@4.4.4(picomatch@4.0.3)(svelte@5.53.7)(typescript@5.9.3):
     dependencies:
@@ -1567,20 +2307,44 @@ snapshots:
       magic-string: 0.30.21
       zimmerframe: 1.1.4
 
+  symbol-tree@3.2.4: {}
+
   tailwindcss@4.2.1: {}
 
   tapable@2.3.0: {}
+
+  tinybench@2.9.0: {}
+
+  tinyexec@1.1.1: {}
 
   tinyglobby@0.2.15:
     dependencies:
       fdir: 6.5.0(picomatch@4.0.3)
       picomatch: 4.0.3
 
+  tinyrainbow@3.1.0: {}
+
+  tldts-core@7.0.28: {}
+
+  tldts@7.0.28:
+    dependencies:
+      tldts-core: 7.0.28
+
   totalist@3.0.1: {}
+
+  tough-cookie@6.0.1:
+    dependencies:
+      tldts: 7.0.28
+
+  tr46@6.0.0:
+    dependencies:
+      punycode: 2.3.1
 
   tslib@2.8.1: {}
 
   typescript@5.9.3: {}
+
+  undici@7.24.7: {}
 
   vite@7.3.1(jiti@2.6.1)(lightningcss@1.31.1):
     dependencies:
@@ -1598,5 +2362,57 @@ snapshots:
   vitefu@1.1.2(vite@7.3.1(jiti@2.6.1)(lightningcss@1.31.1)):
     optionalDependencies:
       vite: 7.3.1(jiti@2.6.1)(lightningcss@1.31.1)
+
+  vitest@4.1.4(jsdom@29.0.2(@noble/hashes@2.0.1))(vite@7.3.1(jiti@2.6.1)(lightningcss@1.31.1)):
+    dependencies:
+      '@vitest/expect': 4.1.4
+      '@vitest/mocker': 4.1.4(vite@7.3.1(jiti@2.6.1)(lightningcss@1.31.1))
+      '@vitest/pretty-format': 4.1.4
+      '@vitest/runner': 4.1.4
+      '@vitest/snapshot': 4.1.4
+      '@vitest/spy': 4.1.4
+      '@vitest/utils': 4.1.4
+      es-module-lexer: 2.0.0
+      expect-type: 1.3.0
+      magic-string: 0.30.21
+      obug: 2.1.1
+      pathe: 2.0.3
+      picomatch: 4.0.3
+      std-env: 4.0.0
+      tinybench: 2.9.0
+      tinyexec: 1.1.1
+      tinyglobby: 0.2.15
+      tinyrainbow: 3.1.0
+      vite: 7.3.1(jiti@2.6.1)(lightningcss@1.31.1)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      jsdom: 29.0.2(@noble/hashes@2.0.1)
+    transitivePeerDependencies:
+      - msw
+
+  w3c-xmlserializer@5.0.0:
+    dependencies:
+      xml-name-validator: 5.0.0
+
+  webidl-conversions@8.0.1: {}
+
+  whatwg-mimetype@5.0.0: {}
+
+  whatwg-url@16.0.1(@noble/hashes@2.0.1):
+    dependencies:
+      '@exodus/bytes': 1.15.0(@noble/hashes@2.0.1)
+      tr46: 6.0.0
+      webidl-conversions: 8.0.1
+    transitivePeerDependencies:
+      - '@noble/hashes'
+
+  why-is-node-running@2.3.0:
+    dependencies:
+      siginfo: 2.0.0
+      stackback: 0.0.2
+
+  xml-name-validator@5.0.0: {}
+
+  xmlchars@2.2.0: {}
 
   zimmerframe@1.1.4: {}

--- a/src/lib/__tests__/NsiteList.test.ts
+++ b/src/lib/__tests__/NsiteList.test.ts
@@ -1,0 +1,455 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, fireEvent, screen, waitFor } from '@testing-library/svelte';
+import type { NostrEvent } from 'nostr-tools';
+import type { NsiteEntry } from '$lib/nostr/loaders';
+
+// Read NsiteList source at import time for static singleton check
+// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+// @ts-ignore — ?raw vite import is valid in vitest context
+import nsiteListSource from '$lib/components/NsiteList.svelte?raw';
+
+// --- Mocks (vi.mock is hoisted — factories run before imports) ---
+
+// Shared mocks for EventFactory — set up in beforeEach
+const mockModify = vi.fn();
+const mockBuild = vi.fn();
+const mockSign = vi.fn();
+
+// Use a function constructor (not arrow fn) to match ThemePicker pattern
+function MockEventFactory(this: any, _opts: unknown) {
+	this.modify = mockModify;
+	this.build = mockBuild;
+	this.sign = mockSign;
+}
+
+vi.mock('applesauce-core/event-factory', () => ({
+	EventFactory: MockEventFactory,
+}));
+
+// setDeleteEvents mock
+const mockSetDeleteEvents = vi.fn().mockReturnValue(vi.fn());
+vi.mock('applesauce-core/operations/delete', () => ({
+	setDeleteEvents: mockSetDeleteEvents,
+}));
+
+vi.mock('$lib/nostr/bootstrap', () => ({
+	BOOTSTRAP_RELAYS: ['wss://relay.damus.io', 'wss://nos.lol'],
+	buildSiteUrl: vi.fn((host: string, _pubkey: string, slug?: string) =>
+		slug ? `https://${slug}.${host}` : `https://${host}`
+	),
+	buildSnapshotUrl: vi.fn((host: string, snapshotId: string) =>
+		`https://v${snapshotId}.${host}`
+	),
+}));
+
+// Imports after mocks
+import NsiteList from '$lib/components/NsiteList.svelte';
+
+// --- Helpers ---
+
+function makeNsiteEntry(overrides: Partial<NsiteEntry> & { sourceEvent?: NostrEvent } = {}): NsiteEntry {
+	const event: NostrEvent = overrides.sourceEvent ?? {
+		id: 'event-abc123',
+		kind: 35128,
+		pubkey: 'pubkey1234',
+		created_at: 1000000,
+		content: '',
+		tags: [['d', 'my-blog'], ['title', 'My Blog'], ['description', 'A test blog']],
+		sig: 'sig',
+	};
+	return {
+		ref: '35128:pubkey1234:my-blog',
+		slug: 'my-blog',
+		isRoot: false,
+		createdAt: 1000000,
+		title: 'My Blog',
+		description: 'A test blog',
+		versions: [],
+		sourceEvent: event,
+		...overrides,
+	};
+}
+
+function makeMockPool() {
+	const sub = { unsubscribe: vi.fn() };
+	const observable = {
+		subscribe: vi.fn((cb: (msg: NostrEvent | 'EOSE') => void) => {
+			cb('EOSE');
+			return sub;
+		}),
+	};
+	return {
+		req: vi.fn().mockReturnValue(observable),
+		publish: vi.fn().mockResolvedValue([]),
+	};
+}
+
+function makeMockSigner(pubkey = 'pubkey1234') {
+	return {
+		getPublicKey: vi.fn().mockResolvedValue(pubkey),
+		signEvent: vi.fn().mockResolvedValue({ sig: 'mocksig' }),
+	};
+}
+
+const defaultProps = {
+	nsites: [makeNsiteEntry()],
+	host: 'npub1test.nsite.lol',
+	pubkey: 'pubkey1234',
+	isOwner: true,
+	writeRelays: ['wss://relay.test'],
+};
+
+// --- Setup ---
+
+beforeEach(() => {
+	vi.clearAllMocks();
+
+	// Default mock resolutions
+	mockModify.mockResolvedValue(vi.fn());
+	mockBuild.mockResolvedValue({ kind: 5, content: '', tags: [] });
+	mockSign.mockResolvedValue({
+		kind: 5,
+		id: 'deletion-event-id',
+		content: '',
+		tags: [],
+		pubkey: 'pubkey1234',
+		created_at: 1000001,
+		sig: 'sig',
+	});
+	mockSetDeleteEvents.mockReturnValue(vi.fn());
+});
+
+// --- NSITE-01/02: Edit icon and inline edit form ---
+
+describe('NsiteList — NSITE-01/02: edit icon and inline edit form', () => {
+	it('shows pencil edit icon for each nsite when isOwner=true', () => {
+		const pool = makeMockPool();
+		const signer = makeMockSigner();
+
+		render(NsiteList, {
+			props: { ...defaultProps, isOwner: true, pool: pool as any, signer },
+		});
+
+		// Expect at least one button with aria-label or title containing "edit" or the pencil character
+		const editButtons = screen.queryAllByRole('button').filter(
+			(b) =>
+				b.getAttribute('aria-label')?.match(/edit/i) ||
+				b.getAttribute('title')?.match(/edit/i) ||
+				b.textContent?.includes('\u270F') ||
+				b.textContent?.includes('\u270E') ||
+				b.textContent?.includes('Edit')
+		);
+		expect(editButtons.length).toBeGreaterThan(0);
+	});
+
+	it('does not show edit icon when isOwner=false', () => {
+		const pool = makeMockPool();
+		const signer = makeMockSigner();
+
+		render(NsiteList, {
+			props: { ...defaultProps, isOwner: false, pool: pool as any, signer },
+		});
+
+		const editButtons = screen.queryAllByRole('button').filter(
+			(b) =>
+				b.getAttribute('aria-label')?.match(/edit/i) ||
+				b.getAttribute('title')?.match(/edit/i) ||
+				b.textContent?.includes('\u270F') ||
+				b.textContent?.includes('\u270E') ||
+				b.textContent?.includes('Edit')
+		);
+		expect(editButtons.length).toBe(0);
+	});
+
+	it('clicking edit icon opens inline form with name and description inputs', async () => {
+		const pool = makeMockPool();
+		const signer = makeMockSigner();
+
+		render(NsiteList, {
+			props: { ...defaultProps, isOwner: true, pool: pool as any, signer },
+		});
+
+		const editButton = screen.queryAllByRole('button').find(
+			(b) =>
+				b.getAttribute('aria-label')?.match(/edit/i) ||
+				b.getAttribute('title')?.match(/edit/i) ||
+				b.textContent?.includes('\u270F') ||
+				b.textContent?.includes('\u270E') ||
+				b.textContent?.includes('Edit')
+		);
+		expect(editButton).toBeTruthy();
+		await fireEvent.click(editButton!);
+
+		// After clicking edit, title and description inputs should appear
+		const inputs = screen.queryAllByRole('textbox');
+		expect(inputs.length).toBeGreaterThanOrEqual(2);
+
+		// At least one input should have the current title or description value
+		const inputValues = inputs.map((i) => (i as HTMLInputElement).value);
+		expect(inputValues.some((v) => v === 'My Blog' || v === 'A test blog')).toBe(true);
+	});
+
+	it('clicking Save calls EventFactory.modify and pool.publish with updated title and description tags', async () => {
+		const pool = makeMockPool();
+		const signer = makeMockSigner();
+
+		render(NsiteList, {
+			props: { ...defaultProps, isOwner: true, pool: pool as any, signer, writeRelays: ['wss://relay.test'] },
+		});
+
+		// Open inline edit form
+		const editButton = screen.queryAllByRole('button').find(
+			(b) =>
+				b.getAttribute('aria-label')?.match(/edit/i) ||
+				b.getAttribute('title')?.match(/edit/i) ||
+				b.textContent?.includes('\u270F') ||
+				b.textContent?.includes('\u270E') ||
+				b.textContent?.includes('Edit')
+		);
+		await fireEvent.click(editButton!);
+
+		// Change title input
+		const inputs = screen.queryAllByRole('textbox');
+		await fireEvent.input(inputs[0], { target: { value: 'Updated Blog' } });
+
+		// Click Save button
+		const saveButton = screen.getByRole('button', { name: /save/i });
+		await fireEvent.click(saveButton);
+
+		// Wait for async publish
+		await waitFor(() => {
+			expect(mockModify).toHaveBeenCalled();
+		}, { timeout: 2000 });
+
+		expect(pool.publish).toHaveBeenCalled();
+	});
+
+	it('publishes to writeRelays when writeRelays is non-empty', async () => {
+		const pool = makeMockPool();
+		const signer = makeMockSigner();
+		const writeRelays = ['wss://relay.test'];
+
+		render(NsiteList, {
+			props: { ...defaultProps, isOwner: true, pool: pool as any, signer, writeRelays },
+		});
+
+		const editButton = screen.queryAllByRole('button').find(
+			(b) =>
+				b.getAttribute('aria-label')?.match(/edit/i) ||
+				b.getAttribute('title')?.match(/edit/i) ||
+				b.textContent?.includes('\u270F') ||
+				b.textContent?.includes('\u270E') ||
+				b.textContent?.includes('Edit')
+		);
+		await fireEvent.click(editButton!);
+
+		const inputs = screen.queryAllByRole('textbox');
+		await fireEvent.input(inputs[0], { target: { value: 'New Title' } });
+
+		const saveButton = screen.getByRole('button', { name: /save/i });
+		await fireEvent.click(saveButton);
+
+		await waitFor(() => {
+			expect(pool.publish).toHaveBeenCalledWith(writeRelays, expect.any(Object));
+		}, { timeout: 2000 });
+	});
+
+	it('falls back to BOOTSTRAP_RELAYS when writeRelays is empty', async () => {
+		const pool = makeMockPool();
+		const signer = makeMockSigner();
+
+		render(NsiteList, {
+			props: { ...defaultProps, isOwner: true, pool: pool as any, signer, writeRelays: [] },
+		});
+
+		const editButton = screen.queryAllByRole('button').find(
+			(b) =>
+				b.getAttribute('aria-label')?.match(/edit/i) ||
+				b.getAttribute('title')?.match(/edit/i) ||
+				b.textContent?.includes('\u270F') ||
+				b.textContent?.includes('\u270E') ||
+				b.textContent?.includes('Edit')
+		);
+		await fireEvent.click(editButton!);
+
+		const inputs = screen.queryAllByRole('textbox');
+		await fireEvent.input(inputs[0], { target: { value: 'New Title' } });
+
+		const saveButton = screen.getByRole('button', { name: /save/i });
+		await fireEvent.click(saveButton);
+
+		// BOOTSTRAP_RELAYS is mocked as ['wss://relay.damus.io', 'wss://nos.lol']
+		await waitFor(() => {
+			expect(pool.publish).toHaveBeenCalledWith(
+				['wss://relay.damus.io', 'wss://nos.lol'],
+				expect.any(Object)
+			);
+		}, { timeout: 2000 });
+	});
+});
+
+// --- NSITE-03/04: Delete confirmation and NIP-09 publish ---
+
+describe('NsiteList — NSITE-03/04: delete confirmation and NIP-09 publish', () => {
+	it('shows trash delete icon for each nsite when isOwner=true', () => {
+		const pool = makeMockPool();
+		const signer = makeMockSigner();
+
+		render(NsiteList, {
+			props: { ...defaultProps, isOwner: true, pool: pool as any, signer },
+		});
+
+		const deleteButtons = screen.queryAllByRole('button').filter(
+			(b) =>
+				b.getAttribute('aria-label')?.match(/delete/i) ||
+				b.getAttribute('title')?.match(/delete/i) ||
+				b.textContent?.includes('\uD83D\uDDD1') ||
+				b.textContent?.includes('Delete') ||
+				b.textContent?.includes('\u2715') ||
+				b.textContent?.includes('\u00D7')
+		);
+		expect(deleteButtons.length).toBeGreaterThan(0);
+	});
+
+	it('clicking delete icon shows inline confirm with best-effort text', async () => {
+		const pool = makeMockPool();
+		const signer = makeMockSigner();
+
+		render(NsiteList, {
+			props: { ...defaultProps, isOwner: true, pool: pool as any, signer },
+		});
+
+		const deleteButton = screen.queryAllByRole('button').find(
+			(b) =>
+				b.getAttribute('aria-label')?.match(/delete/i) ||
+				b.getAttribute('title')?.match(/delete/i) ||
+				b.textContent?.includes('\uD83D\uDDD1') ||
+				b.textContent?.includes('Delete') ||
+				b.textContent?.includes('\u2715') ||
+				b.textContent?.includes('\u00D7')
+		);
+		expect(deleteButton).toBeTruthy();
+		await fireEvent.click(deleteButton!);
+
+		// After clicking delete, confirmation text with best-effort language should appear
+		await waitFor(() => {
+			const text = document.body.textContent ?? '';
+			expect(text).toMatch(/request deletion.*best.effort|best.effort.*deletion|deletion.*request/i);
+		}, { timeout: 2000 });
+	});
+
+	it('confirm delete calls EventFactory.build + setDeleteEvents + pool.publish', async () => {
+		const pool = makeMockPool();
+		const signer = makeMockSigner();
+		const nsiteEntry = makeNsiteEntry();
+
+		render(NsiteList, {
+			props: { ...defaultProps, nsites: [nsiteEntry], isOwner: true, pool: pool as any, signer },
+		});
+
+		// Click the trash/delete icon
+		const deleteButton = screen.queryAllByRole('button').find(
+			(b) =>
+				b.getAttribute('aria-label')?.match(/delete/i) ||
+				b.getAttribute('title')?.match(/delete/i) ||
+				b.textContent?.includes('\uD83D\uDDD1') ||
+				b.textContent?.includes('Delete') ||
+				b.textContent?.includes('\u2715') ||
+				b.textContent?.includes('\u00D7')
+		);
+		await fireEvent.click(deleteButton!);
+
+		// Click the confirm Delete button in the inline confirm dialog
+		const confirmButton = await waitFor(
+			() => screen.getByRole('button', { name: /^delete$/i }),
+			{ timeout: 2000 }
+		);
+		await fireEvent.click(confirmButton);
+
+		// Wait for async deletion to complete
+		await waitFor(() => {
+			expect(mockBuild).toHaveBeenCalled();
+		}, { timeout: 2000 });
+
+		expect(mockSetDeleteEvents).toHaveBeenCalledWith([nsiteEntry.sourceEvent]);
+		expect(pool.publish).toHaveBeenCalled();
+	});
+
+	it('after deletion nsite is removed from the rendered list', async () => {
+		const pool = makeMockPool();
+		const signer = makeMockSigner();
+
+		render(NsiteList, {
+			props: { ...defaultProps, isOwner: true, pool: pool as any, signer },
+		});
+
+		// Confirm the nsite title is visible initially
+		expect(screen.getByText('My Blog')).toBeTruthy();
+
+		const deleteButton = screen.queryAllByRole('button').find(
+			(b) =>
+				b.getAttribute('aria-label')?.match(/delete/i) ||
+				b.getAttribute('title')?.match(/delete/i) ||
+				b.textContent?.includes('\uD83D\uDDD1') ||
+				b.textContent?.includes('Delete') ||
+				b.textContent?.includes('\u2715') ||
+				b.textContent?.includes('\u00D7')
+		);
+		await fireEvent.click(deleteButton!);
+
+		const confirmButton = await waitFor(
+			() => screen.getByRole('button', { name: /^delete$/i }),
+			{ timeout: 2000 }
+		);
+		await fireEvent.click(confirmButton);
+
+		// After deletion, the nsite card should no longer appear in the list
+		await waitFor(() => {
+			expect(screen.queryByText('My Blog')).toBeNull();
+		}, { timeout: 2000 });
+	});
+
+	it('"Deletion requested" indicator appears after successful deletion', async () => {
+		const pool = makeMockPool();
+		const signer = makeMockSigner();
+
+		render(NsiteList, {
+			props: { ...defaultProps, isOwner: true, pool: pool as any, signer },
+		});
+
+		const deleteButton = screen.queryAllByRole('button').find(
+			(b) =>
+				b.getAttribute('aria-label')?.match(/delete/i) ||
+				b.getAttribute('title')?.match(/delete/i) ||
+				b.textContent?.includes('\uD83D\uDDD1') ||
+				b.textContent?.includes('Delete') ||
+				b.textContent?.includes('\u2715') ||
+				b.textContent?.includes('\u00D7')
+		);
+		await fireEvent.click(deleteButton!);
+
+		const confirmButton = await waitFor(
+			() => screen.getByRole('button', { name: /^delete$/i }),
+			{ timeout: 2000 }
+		);
+		await fireEvent.click(confirmButton);
+
+		await waitFor(() => {
+			expect(screen.queryByText(/deletion requested/i)).toBeTruthy();
+		}, { timeout: 2000 });
+	});
+});
+
+// --- Architecture: no singleton imports ---
+
+describe('NsiteList — architecture: no singleton imports', () => {
+	it('has zero imports from $lib/nostr/store', () => {
+		const matches = (nsiteListSource as string).match(/from ['"].*nostr\/store['"]/g) ?? [];
+		expect(matches).toHaveLength(0);
+	});
+
+	it('has zero imports from $lib/auth.svelte', () => {
+		const matches = (nsiteListSource as string).match(/from ['"].*auth\.svelte['"]/g) ?? [];
+		expect(matches).toHaveLength(0);
+	});
+});

--- a/src/lib/__tests__/ThemePicker.test.ts
+++ b/src/lib/__tests__/ThemePicker.test.ts
@@ -1,0 +1,383 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, fireEvent, screen, waitFor } from '@testing-library/svelte';
+import type { NostrEvent } from 'nostr-tools';
+
+// Read ThemePicker source at import time (vitest supports ?raw imports for text content)
+// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+// @ts-ignore — ?raw vite import is valid in vitest context
+import themePickerSource from '$lib/components/ThemePicker.svelte?raw';
+
+// --- Mocks (vi.mock is hoisted — factories run before imports) ---
+
+vi.mock('$lib/theme', () => ({
+	applyTheme: vi.fn(),
+	clearTheme: vi.fn(),
+	parseThemeDefinition: vi.fn(),
+	decodeNeventInput: vi.fn(),
+}));
+
+vi.mock('$lib/nostr/bootstrap', () => ({
+	BOOTSTRAP_RELAYS: ['wss://relay.damus.io', 'wss://nos.lol'],
+}));
+
+// Shared mocks for EventFactory build and sign — set up in beforeEach
+// These are module-level so vi.mock factory can reference them via closure.
+const mockBuild = vi.fn();
+const mockSign = vi.fn();
+
+// Mock EventFactory from applesauce-core/event-factory
+// Use a function constructor (not arrow fn) so vitest doesn't warn about class mocking.
+function MockEventFactory(this: any, _opts: unknown) {
+	this.build = mockBuild;
+	this.sign = mockSign;
+}
+
+vi.mock('applesauce-core/event-factory', () => ({
+	EventFactory: MockEventFactory,
+}));
+
+// Imports after mocks
+import { applyTheme, clearTheme, parseThemeDefinition, decodeNeventInput } from '$lib/theme';
+import ThemePicker from '$lib/components/ThemePicker.svelte';
+
+// --- Helpers ---
+
+/** Build a minimal kind 36767 NostrEvent for testing. */
+function makeThemeEvent(id: string, title: string, bg = '#1a1a2e', text = '#e0e0e0', primary = '#7c5cbf'): NostrEvent {
+	return {
+		id,
+		kind: 36767,
+		pubkey: 'aabbccdd1234567890aabbccdd1234567890aabbccdd1234567890aabbccdd12',
+		created_at: 1000000,
+		content: '',
+		tags: [
+			['d', `d-${id}`],
+			['title', title],
+			['c', bg, 'background'],
+			['c', text, 'text'],
+			['c', primary, 'primary'],
+			['alt', `Custom theme: ${title}`],
+		],
+		sig: 'sig',
+	};
+}
+
+/** Create a mock pool. When given an event, subscribe emits it then EOSE synchronously. */
+function makeMockPool(event?: NostrEvent) {
+	const sub = { unsubscribe: vi.fn() };
+	const observable = {
+		subscribe: vi.fn((cb: (msg: NostrEvent | 'EOSE') => void) => {
+			if (event) cb(event);
+			cb('EOSE');
+			return sub;
+		}),
+	};
+	const pool = {
+		req: vi.fn().mockReturnValue(observable),
+		publish: vi.fn().mockResolvedValue([]),
+	};
+	return pool;
+}
+
+/** Create a mock EventSigner. */
+function makeMockSigner(pubkey = 'deadbeef') {
+	return {
+		getPublicKey: vi.fn().mockResolvedValue(pubkey),
+		// EventSigner interface requires signEvent
+		signEvent: vi.fn().mockResolvedValue({ sig: 'mocksig' }),
+	};
+}
+
+const defaultProps = {
+	pubkey: 'testpubkey1234',
+	writeRelays: ['wss://relay.test'],
+	onclose: vi.fn(),
+};
+
+// --- Setup ---
+
+beforeEach(() => {
+	vi.clearAllMocks();
+
+	// Default: parseThemeDefinition returns a valid theme
+	vi.mocked(parseThemeDefinition).mockReturnValue({
+		colors: { background: '228 20% 10%', text: '210 40% 98%', primary: '258 70% 60%' },
+	});
+	// Default: decodeNeventInput returns a fake decoded ref (so curated fetch runs)
+	vi.mocked(decodeNeventInput).mockReturnValue({
+		id: 'fakeid00001',
+		relays: ['wss://relay.damus.io'],
+	});
+
+	// Configure EventFactory instance mocks
+	mockBuild.mockResolvedValue({ kind: 16767, content: '', tags: [] });
+	mockSign.mockResolvedValue({
+		kind: 16767,
+		id: 'signedid',
+		content: '',
+		tags: [],
+		pubkey: 'deadbeef',
+		created_at: 1000001,
+		sig: 'sig',
+	});
+});
+
+// --- THEME-04: applyTheme called when theme card is clicked ---
+
+describe('ThemePicker — THEME-04: applyTheme on card click', () => {
+	it('calls applyTheme with the parsed theme when a theme card is clicked', async () => {
+		const themeEvent = makeThemeEvent('abc123', 'Ocean Night');
+		const parsedTheme = {
+			colors: { background: '228 20% 10%', text: '210 40% 98%', primary: '258 70% 60%' },
+		};
+
+		// decodeNeventInput returns a valid id so pool.req fires
+		vi.mocked(decodeNeventInput).mockReturnValue({ id: 'abc123', relays: ['wss://relay.damus.io'] });
+		vi.mocked(parseThemeDefinition).mockReturnValue(parsedTheme);
+
+		const pool = makeMockPool(themeEvent);
+		const signer = makeMockSigner();
+
+		render(ThemePicker, {
+			props: { ...defaultProps, signer, pool: pool as any },
+		});
+
+		// Wait for loading to finish (3s timer) + theme cards to appear
+		await waitFor(() => {
+			const cards = screen.queryAllByRole('button').filter((b) => b.hasAttribute('aria-pressed'));
+			expect(cards.length).toBeGreaterThan(0);
+		}, { timeout: 4000 });
+
+		// Click the first theme card
+		const cards = screen.queryAllByRole('button').filter((b) => b.hasAttribute('aria-pressed'));
+		await fireEvent.click(cards[0]);
+
+		expect(applyTheme).toHaveBeenCalledWith(parsedTheme);
+	});
+
+	it('applyTheme is not called before any card is clicked', async () => {
+		const pool = makeMockPool();
+		const signer = makeMockSigner();
+
+		render(ThemePicker, {
+			props: { ...defaultProps, signer, pool: pool as any },
+		});
+
+		// At mount time, applyTheme should not have been called
+		expect(applyTheme).not.toHaveBeenCalled();
+	});
+});
+
+// --- THEME-05: EventFactory.build + sign + pool.publish on Apply Theme ---
+
+describe('ThemePicker — THEME-05: publish kind 16767 on Apply Theme', () => {
+	it('calls EventFactory.build, sign, and pool.publish when Apply Theme is clicked after selecting a theme', async () => {
+		const themeEvent = makeThemeEvent('theme01', 'Test Theme');
+		const parsedTheme = {
+			colors: { background: '228 20% 10%', text: '210 40% 98%', primary: '258 70% 60%' },
+		};
+		const onclose = vi.fn();
+
+		vi.mocked(decodeNeventInput).mockReturnValue({ id: 'theme01', relays: ['wss://relay.damus.io'] });
+		vi.mocked(parseThemeDefinition).mockReturnValue(parsedTheme);
+
+		const pool = makeMockPool(themeEvent);
+		const signer = makeMockSigner();
+
+		render(ThemePicker, {
+			props: { ...defaultProps, signer, pool: pool as any, onclose },
+		});
+
+		// Wait for theme cards
+		await waitFor(() => {
+			const cards = screen.queryAllByRole('button').filter((b) => b.hasAttribute('aria-pressed'));
+			expect(cards.length).toBeGreaterThan(0);
+		}, { timeout: 4000 });
+
+		// Click a theme card to select it
+		const cards = screen.queryAllByRole('button').filter((b) => b.hasAttribute('aria-pressed'));
+		await fireEvent.click(cards[0]);
+
+		// Click Apply Theme
+		const applyButton = screen.getByRole('button', { name: /apply theme/i });
+		expect(applyButton).not.toBeDisabled();
+		await fireEvent.click(applyButton);
+
+		// Wait for async publish
+		await waitFor(() => {
+			expect(mockBuild).toHaveBeenCalled();
+		}, { timeout: 2000 });
+
+		expect(mockSign).toHaveBeenCalled();
+		expect(pool.publish).toHaveBeenCalled();
+	});
+
+	it('publishes to writeRelays when writeRelays is non-empty', async () => {
+		const themeEvent = makeThemeEvent('theme02', 'Test Theme 2');
+		const writeRelays = ['wss://custom.relay', 'wss://another.relay'];
+		const onclose = vi.fn();
+
+		vi.mocked(decodeNeventInput).mockReturnValue({ id: 'theme02', relays: ['wss://relay.damus.io'] });
+		vi.mocked(parseThemeDefinition).mockReturnValue({
+			colors: { background: '0 0% 10%', text: '0 0% 90%', primary: '240 70% 60%' },
+		});
+
+		const pool = makeMockPool(themeEvent);
+		const signer = makeMockSigner();
+
+		render(ThemePicker, {
+			props: { pubkey: 'testpubkey', signer, pool: pool as any, writeRelays, onclose },
+		});
+
+		await waitFor(() => {
+			const cards = screen.queryAllByRole('button').filter((b) => b.hasAttribute('aria-pressed'));
+			expect(cards.length).toBeGreaterThan(0);
+		}, { timeout: 4000 });
+
+		const cards = screen.queryAllByRole('button').filter((b) => b.hasAttribute('aria-pressed'));
+		await fireEvent.click(cards[0]);
+
+		const applyButton = screen.getByRole('button', { name: /apply theme/i });
+		await fireEvent.click(applyButton);
+
+		await waitFor(() => {
+			expect(pool.publish).toHaveBeenCalledWith(writeRelays, expect.any(Object));
+		}, { timeout: 2000 });
+	});
+
+	it('falls back to BOOTSTRAP_RELAYS when writeRelays is empty', async () => {
+		const themeEvent = makeThemeEvent('theme03', 'Test Theme 3');
+		const onclose = vi.fn();
+
+		vi.mocked(decodeNeventInput).mockReturnValue({ id: 'theme03', relays: ['wss://relay.damus.io'] });
+		vi.mocked(parseThemeDefinition).mockReturnValue({
+			colors: { background: '0 0% 10%', text: '0 0% 90%', primary: '20 100% 50%' },
+		});
+
+		const pool = makeMockPool(themeEvent);
+		const signer = makeMockSigner();
+
+		render(ThemePicker, {
+			props: { pubkey: 'testpubkey', signer, pool: pool as any, writeRelays: [], onclose },
+		});
+
+		await waitFor(() => {
+			const cards = screen.queryAllByRole('button').filter((b) => b.hasAttribute('aria-pressed'));
+			expect(cards.length).toBeGreaterThan(0);
+		}, { timeout: 4000 });
+
+		const cards = screen.queryAllByRole('button').filter((b) => b.hasAttribute('aria-pressed'));
+		await fireEvent.click(cards[0]);
+
+		const applyButton = screen.getByRole('button', { name: /apply theme/i });
+		await fireEvent.click(applyButton);
+
+		// BOOTSTRAP_RELAYS is mocked as ['wss://relay.damus.io', 'wss://nos.lol']
+		await waitFor(() => {
+			expect(pool.publish).toHaveBeenCalledWith(
+				['wss://relay.damus.io', 'wss://nos.lol'],
+				expect.any(Object)
+			);
+		}, { timeout: 2000 });
+	});
+});
+
+// --- THEME-06: No singleton imports (static file check) ---
+
+describe('ThemePicker — THEME-06: no singleton imports', () => {
+	it('has zero imports from $lib/nostr/store', () => {
+		// themePickerSource is the raw .svelte file content imported via Vite's ?raw
+		const matches = (themePickerSource as string).match(/from ['"].*nostr\/store['"]/g) ?? [];
+		expect(matches).toHaveLength(0);
+	});
+
+	it('has zero imports from $lib/auth.svelte', () => {
+		const matches = (themePickerSource as string).match(/from ['"].*auth\.svelte['"]/g) ?? [];
+		expect(matches).toHaveLength(0);
+	});
+});
+
+// --- Modal behavior ---
+
+describe('ThemePicker — modal behavior', () => {
+	it('renders the modal title "Pick a Theme"', () => {
+		const pool = makeMockPool();
+		const signer = makeMockSigner();
+
+		render(ThemePicker, {
+			props: { ...defaultProps, signer, pool: pool as any },
+		});
+
+		expect(screen.getByText('Pick a Theme')).toBeTruthy();
+	});
+
+	it('calls clearTheme and onclose when close button (&#x2715;) is clicked', async () => {
+		const pool = makeMockPool();
+		const signer = makeMockSigner();
+		const onclose = vi.fn();
+
+		render(ThemePicker, {
+			props: { ...defaultProps, signer, pool: pool as any, onclose },
+		});
+
+		const closeButton = screen.getByRole('button', { name: /close/i });
+		await fireEvent.click(closeButton);
+
+		expect(clearTheme).toHaveBeenCalled();
+		expect(onclose).toHaveBeenCalled();
+	});
+
+	it('calls clearTheme and onclose when Keep Current Theme is clicked', async () => {
+		const pool = makeMockPool();
+		const signer = makeMockSigner();
+		const onclose = vi.fn();
+
+		render(ThemePicker, {
+			props: { ...defaultProps, signer, pool: pool as any, onclose },
+		});
+
+		const keepButton = screen.getByRole('button', { name: /keep current theme/i });
+		await fireEvent.click(keepButton);
+
+		expect(clearTheme).toHaveBeenCalled();
+		expect(onclose).toHaveBeenCalled();
+	});
+
+	it('Apply Theme button is disabled when no theme is selected', () => {
+		const pool = makeMockPool();
+		const signer = makeMockSigner();
+
+		render(ThemePicker, {
+			props: { ...defaultProps, signer, pool: pool as any },
+		});
+
+		const applyButton = screen.getByRole('button', { name: /apply theme/i });
+		expect(applyButton).toBeDisabled();
+	});
+
+	it('shows nevent error when addCustomTheme is called with an invalid reference', async () => {
+		const pool = makeMockPool();
+		const signer = makeMockSigner();
+
+		// decodeNeventInput returns null for invalid input
+		vi.mocked(decodeNeventInput).mockReturnValueOnce(null); // curated skipped
+		vi.mocked(decodeNeventInput).mockReturnValueOnce(null); // custom input decode fails
+
+		render(ThemePicker, {
+			props: { ...defaultProps, signer, pool: pool as any },
+		});
+
+		// Type an invalid nevent reference
+		const input = screen.getByPlaceholderText('nevent1...');
+		await fireEvent.input(input, { target: { value: 'invalid-nevent-ref' } });
+
+		// Click Add Theme
+		const addButton = screen.getByRole('button', { name: /add theme/i });
+		await fireEvent.click(addButton);
+
+		// Error message should appear
+		await waitFor(() => {
+			expect(screen.queryByText(/could not fetch theme/i)).toBeTruthy();
+		});
+	});
+});

--- a/src/lib/__tests__/auth.test.ts
+++ b/src/lib/__tests__/auth.test.ts
@@ -1,0 +1,199 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// --- Mocks ---
+// vi.mock is hoisted — all factory code runs before module imports.
+// Factory must be self-contained (no references to outer variables).
+
+vi.mock('applesauce-signers', () => {
+	// Use regular function constructors (not arrow functions) — required for `new` to work
+	function MockExtensionSigner(this: any) {
+		this.getPublicKey = vi.fn().mockResolvedValue('aabbccdd');
+	}
+
+	function MockNostrConnectSigner(this: any) {
+		this.getPublicKey = vi.fn().mockResolvedValue('ddeeff00');
+		this.getNostrConnectURI = vi.fn().mockReturnValue('nostrconnect://mock');
+		this.close = vi.fn();
+	}
+	// static method — attached before export
+	(MockNostrConnectSigner as any).fromBunkerURI = vi.fn().mockResolvedValue({
+		getPublicKey: vi.fn().mockResolvedValue('112233aa'),
+		close: vi.fn(),
+	});
+
+	return {
+		ExtensionSigner: MockExtensionSigner,
+		NostrConnectSigner: MockNostrConnectSigner,
+	};
+});
+
+vi.mock('$lib/nostr/store', () => ({
+	pool: { req: vi.fn(), publish: vi.fn() },
+}));
+
+vi.mock('$lib/nostr/bootstrap', () => ({
+	parseNpubFromHostname: vi.fn().mockReturnValue({ npub: 'npub1test', pubkey: 'aabbccdd' }),
+}));
+
+// Imports after mocks
+import {
+	loginWithExtension,
+	loginWithBunker,
+	logout,
+	restoreSession,
+	getSignerPubkey,
+	getSigner,
+} from '$lib/auth.svelte';
+
+import { NostrConnectSigner } from 'applesauce-signers';
+
+// Reset state before each test
+beforeEach(() => {
+	localStorage.clear();
+	// logout() resets signerPubkey and signer to null
+	logout();
+	// Reset fromBunkerURI to default (in case a test overrode it)
+	vi.mocked(NostrConnectSigner.fromBunkerURI).mockResolvedValue({
+		getPublicKey: vi.fn().mockResolvedValue('112233aa'),
+		close: vi.fn(),
+	} as any);
+});
+
+// --- NIP-07 (AUTH-01) ---
+
+describe('auth singleton — NIP-07 (AUTH-01)', () => {
+	it('loginWithExtension calls getPublicKey and sets signerPubkey', async () => {
+		await loginWithExtension();
+		expect(getSignerPubkey()).toBe('aabbccdd');
+	});
+
+	it('loginWithExtension persists auth:type=nip07 to localStorage', async () => {
+		await loginWithExtension();
+		expect(localStorage.getItem('auth:type')).toBe('nip07');
+	});
+
+	it('loginWithExtension sets a non-null signer', async () => {
+		await loginWithExtension();
+		expect(getSigner()).not.toBeNull();
+	});
+});
+
+// --- NIP-46 bunker paste (AUTH-02) ---
+
+describe('auth singleton — NIP-46 bunker paste (AUTH-02)', () => {
+	it('loginWithBunker calls NostrConnectSigner.fromBunkerURI with given URI', async () => {
+		await loginWithBunker('bunker://aabbccdd?relay=wss://bucket.coracle.social');
+		expect(vi.mocked(NostrConnectSigner.fromBunkerURI)).toHaveBeenCalledWith(
+			'bunker://aabbccdd?relay=wss://bucket.coracle.social',
+			expect.any(Object)
+		);
+	});
+
+	it('loginWithBunker sets signerPubkey from getPublicKey(), NOT from bunker URI pubkey', async () => {
+		// bunker URI contains 'aabbccdd' but getPublicKey returns '112233aa'
+		// signerPubkey must be '112233aa' — verifies we call signer.getPublicKey, not parse URI
+		await loginWithBunker('bunker://aabbccdd?relay=wss://bucket.coracle.social');
+		expect(getSignerPubkey()).toBe('112233aa');
+		expect(getSignerPubkey()).not.toBe('aabbccdd');
+	});
+
+	it('loginWithBunker persists auth:type=nip46 to localStorage', async () => {
+		await loginWithBunker('bunker://aabbccdd?relay=wss://bucket.coracle.social');
+		expect(localStorage.getItem('auth:type')).toBe('nip46');
+	});
+
+	it('loginWithBunker persists bunker_uri to localStorage', async () => {
+		const uri = 'bunker://aabbccdd?relay=wss://bucket.coracle.social';
+		await loginWithBunker(uri);
+		expect(localStorage.getItem('auth:bunker_uri')).toBe(uri);
+	});
+});
+
+// --- Session persistence (AUTH-06) ---
+
+describe('auth singleton — session persistence (AUTH-06)', () => {
+	it('restoreSession with type=nip07 creates ExtensionSigner and sets signerPubkey', async () => {
+		localStorage.setItem('auth:type', 'nip07');
+		await restoreSession();
+		expect(getSignerPubkey()).toBe('aabbccdd');
+	});
+
+	it('restoreSession with type=nip46 calls fromBunkerURI and sets signerPubkey', async () => {
+		localStorage.setItem('auth:type', 'nip46');
+		localStorage.setItem('auth:bunker_uri', 'bunker://remote?relay=wss://bucket.coracle.social');
+		localStorage.setItem('auth:relay', 'wss://bucket.coracle.social');
+		await restoreSession();
+		expect(getSignerPubkey()).toBe('112233aa');
+	});
+
+	it('restoreSession with missing bunker_uri clears localStorage silently', async () => {
+		localStorage.setItem('auth:type', 'nip46');
+		// intentionally omit auth:bunker_uri
+		await restoreSession();
+		expect(getSignerPubkey()).toBeNull();
+		expect(localStorage.getItem('auth:type')).toBeNull();
+	});
+
+	it('restoreSession does nothing when auth:type is absent', async () => {
+		await restoreSession();
+		expect(getSignerPubkey()).toBeNull();
+	});
+
+	it('restoreSession clears localStorage when signer connection fails', async () => {
+		vi.mocked(NostrConnectSigner.fromBunkerURI).mockRejectedValueOnce(new Error('connection failed'));
+		localStorage.setItem('auth:type', 'nip46');
+		localStorage.setItem('auth:bunker_uri', 'bunker://remote?relay=wss://bucket.coracle.social');
+		localStorage.setItem('auth:relay', 'wss://bucket.coracle.social');
+		await restoreSession();
+		expect(getSignerPubkey()).toBeNull();
+		expect(localStorage.getItem('auth:type')).toBeNull();
+	});
+});
+
+// --- Logout (AUTH-07) ---
+
+describe('auth singleton — logout (AUTH-07)', () => {
+	it('logout sets signerPubkey to null after loginWithExtension', async () => {
+		await loginWithExtension();
+		expect(getSignerPubkey()).toBe('aabbccdd');
+		logout();
+		expect(getSignerPubkey()).toBeNull();
+	});
+
+	it('logout removes auth:type from localStorage', async () => {
+		await loginWithExtension();
+		logout();
+		expect(localStorage.getItem('auth:type')).toBeNull();
+	});
+
+	it('logout removes auth:bunker_uri from localStorage', async () => {
+		await loginWithBunker('bunker://aabbccdd?relay=wss://bucket.coracle.social');
+		logout();
+		expect(localStorage.getItem('auth:bunker_uri')).toBeNull();
+	});
+
+	it('logout removes auth:relay from localStorage', async () => {
+		await loginWithBunker('bunker://aabbccdd?relay=wss://bucket.coracle.social');
+		logout();
+		expect(localStorage.getItem('auth:relay')).toBeNull();
+	});
+
+	it('logout calls signer.close() on NIP-46 signer', async () => {
+		const mockClose = vi.fn();
+		// Return a real instance of the mock constructor so instanceof check passes
+		const instance = new (NostrConnectSigner as any)();
+		instance.getPublicKey = vi.fn().mockResolvedValue('112233aa');
+		instance.close = mockClose;
+		vi.mocked(NostrConnectSigner.fromBunkerURI).mockResolvedValueOnce(instance);
+		await loginWithBunker('bunker://aabbccdd?relay=wss://bucket.coracle.social');
+		logout();
+		expect(mockClose).toHaveBeenCalledOnce();
+	});
+});
+
+// --- isOwner note ---
+// isOwner() is a function returning a $derived Svelte 5 rune value.
+// It computes: signerPubkey !== null && signerPubkey === parseNpubFromHostname(hostname)?.pubkey
+// In unit tests without a Svelte component tree the derived computation runs synchronously,
+// but full reactivity tracking isn't available. isOwner() is covered in the manual
+// test checklist in .planning/phases/01-auth/01-VALIDATION.md.

--- a/src/lib/__tests__/qr.test.ts
+++ b/src/lib/__tests__/qr.test.ts
@@ -1,0 +1,29 @@
+import { describe, it, expect, vi } from 'vitest';
+
+// Mock lean-qr before any imports that depend on it
+const toCanvasMock = vi.fn();
+vi.mock('lean-qr', () => ({
+	generate: vi.fn(() => ({ toCanvas: toCanvasMock })),
+}));
+
+import { generate } from 'lean-qr';
+
+describe('QR code rendering (AUTH-03, AUTH-04)', () => {
+	it('calls generate with the nostrconnect:// URI', () => {
+		const uri = 'nostrconnect://testpubkey?relay=wss%3A%2F%2Fbucket.coracle.social';
+		const canvas = document.createElement('canvas');
+		generate(uri).toCanvas(canvas, { on: [0x8b, 0x5c, 0xf6, 0xff], off: [0, 0, 0, 0], pad: 2 });
+		expect(generate).toHaveBeenCalledWith(uri);
+		expect(toCanvasMock).toHaveBeenCalledWith(canvas, expect.objectContaining({ pad: 2 }));
+	});
+
+	it('toCanvas is called with primary purple color [0x8b, 0x5c, 0xf6, 0xff]', () => {
+		const uri = 'nostrconnect://test';
+		const canvas = document.createElement('canvas');
+		generate(uri).toCanvas(canvas, { on: [0x8b, 0x5c, 0xf6, 0xff], off: [0, 0, 0, 0], pad: 2 });
+		expect(toCanvasMock).toHaveBeenCalledWith(
+			canvas,
+			expect.objectContaining({ on: [0x8b, 0x5c, 0xf6, 0xff] })
+		);
+	});
+});

--- a/src/lib/__tests__/setup.ts
+++ b/src/lib/__tests__/setup.ts
@@ -1,0 +1,1 @@
+import '@testing-library/jest-dom';

--- a/src/lib/__tests__/theme.test.ts
+++ b/src/lib/__tests__/theme.test.ts
@@ -1,0 +1,197 @@
+import { describe, it, expect } from 'vitest';
+import { parseThemeDefinition, decodeNeventInput } from '$lib/theme';
+import type { NostrEvent } from 'nostr-tools';
+
+// ─── Fixtures ────────────────────────────────────────────────────────────────
+
+const TEST_ID = 'a'.repeat(64);
+// Pre-encoded bech32 strings generated with nostr-tools nip19
+const NEVENT_NO_RELAY = 'nevent1qqs242424242424242424242424242424242424242424242424242s7c3tw2';
+const NEVENT_WITH_RELAY = 'nevent1qythwumn8ghj7un9d3shjtn90psk6urvv5hxxmmdqqs242424242424242424242424242424242424242424242424242sxemysv';
+const NOTE_STR = 'note1424242424242424242424242424242424242424242424242424qv3q9y6';
+const NPUB_STR = 'npub1hwamhwamhwamhwamhwamhwamhwamhwamhwamhwamhwamhwamhwasxw04hu';
+const NADDR_36767 = 'naddr1qvzqqqy0nupzpnxvenxvenxvenxvenxvenxvenxvenxvenxvenxvenxvenxvenxvqythwumn8ghj7un9d3shjtn90psk6urvv5hxxmmdqqz8getnwsppl074';
+
+function makeEvent(overrides: Partial<NostrEvent> = {}): NostrEvent {
+	return {
+		id: 'deadbeef'.repeat(8),
+		pubkey: '1234abcd'.repeat(8),
+		created_at: 1700000000,
+		kind: 36767,
+		content: '',
+		sig: 'ff'.repeat(32),
+		tags: [
+			['c', '#1a1b2e', 'background'],
+			['c', '#e0e0f0', 'text'],
+			['c', '#6c63ff', 'primary'],
+		],
+		...overrides,
+	};
+}
+
+// ─── parseThemeDefinition ────────────────────────────────────────────────────
+
+describe('parseThemeDefinition', () => {
+	it('returns ActiveProfileTheme for a valid kind 36767 event with c tags', () => {
+		const result = parseThemeDefinition(makeEvent());
+		expect(result).not.toBeNull();
+		expect(result!.colors).toBeDefined();
+		expect(result!.colors.background).toBeTruthy();
+		expect(result!.colors.text).toBeTruthy();
+		expect(result!.colors.primary).toBeTruthy();
+	});
+
+	it('returns null for kind 16767 (wrong kind)', () => {
+		const result = parseThemeDefinition(makeEvent({ kind: 16767 }));
+		expect(result).toBeNull();
+	});
+
+	it('returns null for kind 1 (wrong kind)', () => {
+		const result = parseThemeDefinition(makeEvent({ kind: 1 }));
+		expect(result).toBeNull();
+	});
+
+	it('returns null when required c tags are missing', () => {
+		const result = parseThemeDefinition(makeEvent({ tags: [] }));
+		expect(result).toBeNull();
+	});
+
+	it('returns null when only some c tags are present (missing primary)', () => {
+		const result = parseThemeDefinition(makeEvent({
+			tags: [
+				['c', '#1a1b2e', 'background'],
+				['c', '#e0e0f0', 'text'],
+			],
+		}));
+		expect(result).toBeNull();
+	});
+
+	it('populates font field when f tag is present', () => {
+		const result = parseThemeDefinition(makeEvent({
+			tags: [
+				['c', '#1a1b2e', 'background'],
+				['c', '#e0e0f0', 'text'],
+				['c', '#6c63ff', 'primary'],
+				['f', 'Inter', 'https://fonts.example.com/inter.woff2'],
+			],
+		}));
+		expect(result).not.toBeNull();
+		expect(result!.font).toBeDefined();
+		expect(result!.font!.family).toBe('Inter');
+		expect(result!.font!.url).toBe('https://fonts.example.com/inter.woff2');
+	});
+
+	it('font field is undefined when f tag is absent', () => {
+		const result = parseThemeDefinition(makeEvent());
+		expect(result).not.toBeNull();
+		expect(result!.font).toBeUndefined();
+	});
+
+	it('populates background field when bg tag is present', () => {
+		const result = parseThemeDefinition(makeEvent({
+			tags: [
+				['c', '#1a1b2e', 'background'],
+				['c', '#e0e0f0', 'text'],
+				['c', '#6c63ff', 'primary'],
+				['bg', 'url https://example.com/bg.jpg', 'mode cover'],
+			],
+		}));
+		expect(result).not.toBeNull();
+		expect(result!.background).toBeDefined();
+		expect(result!.background!.url).toBe('https://example.com/bg.jpg');
+	});
+
+	it('background field is undefined when bg tag is absent', () => {
+		const result = parseThemeDefinition(makeEvent());
+		expect(result).not.toBeNull();
+		expect(result!.background).toBeUndefined();
+	});
+
+	it('sanitizes font family: sets font to undefined when family contains semicolons (CSS injection)', () => {
+		const result = parseThemeDefinition(makeEvent({
+			tags: [
+				['c', '#1a1b2e', 'background'],
+				['c', '#e0e0f0', 'text'],
+				['c', '#6c63ff', 'primary'],
+				['f', 'Evil; color: red', 'https://fonts.example.com/evil.woff2'],
+			],
+		}));
+		expect(result).not.toBeNull();
+		expect(result!.font).toBeUndefined();
+	});
+
+	it('sanitizes font family: sets font to undefined when family contains braces', () => {
+		const result = parseThemeDefinition(makeEvent({
+			tags: [
+				['c', '#1a1b2e', 'background'],
+				['c', '#e0e0f0', 'text'],
+				['c', '#6c63ff', 'primary'],
+				['f', 'Evil{inject}', 'https://fonts.example.com/evil.woff2'],
+			],
+		}));
+		expect(result).not.toBeNull();
+		expect(result!.font).toBeUndefined();
+	});
+
+	it('allows font families with spaces, numbers, hyphens, and underscores', () => {
+		const result = parseThemeDefinition(makeEvent({
+			tags: [
+				['c', '#1a1b2e', 'background'],
+				['c', '#e0e0f0', 'text'],
+				['c', '#6c63ff', 'primary'],
+				['f', 'Open Sans 400', 'https://fonts.example.com/opensans.woff2'],
+			],
+		}));
+		expect(result).not.toBeNull();
+		expect(result!.font).toBeDefined();
+		expect(result!.font!.family).toBe('Open Sans 400');
+	});
+});
+
+// ─── decodeNeventInput ───────────────────────────────────────────────────────
+
+describe('decodeNeventInput', () => {
+	it('returns { id, relays: [] } for a valid nevent1 string without relay hints', () => {
+		const result = decodeNeventInput(NEVENT_NO_RELAY);
+		expect(result).not.toBeNull();
+		expect(result!.id).toBe(TEST_ID);
+		expect(result!.relays).toEqual([]);
+	});
+
+	it('returns { id, relays } for a nevent1 string with relay hints', () => {
+		const result = decodeNeventInput(NEVENT_WITH_RELAY);
+		expect(result).not.toBeNull();
+		expect(result!.id).toBe(TEST_ID);
+		expect(result!.relays).toEqual(['wss://relay.example.com']);
+	});
+
+	it('returns { id, relays: [] } for a bare note1 string', () => {
+		const result = decodeNeventInput(NOTE_STR);
+		expect(result).not.toBeNull();
+		expect(result!.id).toBe(TEST_ID);
+		expect(result!.relays).toEqual([]);
+	});
+
+	it('returns null for an invalid bech32 string', () => {
+		const result = decodeNeventInput('notanevent');
+		expect(result).toBeNull();
+	});
+
+	it('returns null for a npub bech32 (wrong type)', () => {
+		const result = decodeNeventInput(NPUB_STR);
+		expect(result).toBeNull();
+	});
+
+	it('returns { id: \'\', relays } for a naddr bech32 of kind 36767', () => {
+		const result = decodeNeventInput(NADDR_36767);
+		expect(result).not.toBeNull();
+		expect(result!.id).toBe('');
+		expect(result!.relays).toEqual(['wss://relay.example.com']);
+	});
+
+	it('handles trimming of surrounding whitespace', () => {
+		const result = decodeNeventInput('  ' + NOTE_STR + '  ');
+		expect(result).not.toBeNull();
+		expect(result!.id).toBe(TEST_ID);
+	});
+});

--- a/src/lib/auth.svelte.ts
+++ b/src/lib/auth.svelte.ts
@@ -1,0 +1,184 @@
+import { ExtensionSigner, NostrConnectSigner } from 'applesauce-signers';
+import { parseNpubFromHostname } from '$lib/nostr/bootstrap';
+import { pool } from '$lib/nostr/store';
+
+// --- localStorage keys ---
+const KEY_TYPE = 'auth:type';
+const KEY_BUNKER_URI = 'auth:bunker_uri';
+const KEY_RELAY = 'auth:relay';
+
+const DEFAULT_RELAY = 'wss://bucket.coracle.social';
+
+// --- Reactive state (Svelte 5 .svelte.ts runes) ---
+let signer = $state<ExtensionSigner | NostrConnectSigner | null>(null);
+let signerPubkey = $state<string | null>(null);
+
+// --- Derived ---
+// Guard with typeof window !== 'undefined' per RESEARCH.md Pitfall 3
+// NOTE: Svelte 5 does not allow exporting $derived directly from .svelte.ts modules —
+// must export a getter function. Components call isOwner() as a function.
+const _isOwner = $derived.by(() => {
+	if (signerPubkey === null || typeof window === 'undefined') return false;
+	const parsed = parseNpubFromHostname(window.location.hostname);
+	if (!parsed || parsed.type === 'snapshot') return false;
+	return signerPubkey === parsed.pubkey;
+});
+
+/** Returns whether the logged-in signer pubkey matches the site's owner pubkey */
+export function isOwner(): boolean {
+	return _isOwner;
+}
+
+// --- Pool adapter helpers ---
+// TODO: verify type compat with applesauce-signers NostrSubscriptionMethod
+// pool.req returns Observable<SubscriptionResponse> which is Observable<NostrEvent | "EOSE">
+// NostrSubscriptionMethod expects (relays: string[], filters: Filter[]) => ObservableInput<NostrEvent | string>
+// These are compatible at runtime — the cast suppresses TypeScript's structural check
+function poolMethods() {
+	return {
+		subscriptionMethod: (relays: string[], filters: object[]) =>
+			// eslint-disable-next-line @typescript-eslint/no-explicit-any
+			pool.req(relays, filters as any) as any,
+		publishMethod: (relays: string[], event: object) =>
+			// eslint-disable-next-line @typescript-eslint/no-explicit-any
+			pool.publish(relays, event as any) as any,
+	};
+}
+
+// --- localStorage helpers ---
+function persistNip07(): void {
+	localStorage.setItem(KEY_TYPE, 'nip07');
+}
+
+function persistNip46(bunkerUri: string, relay: string): void {
+	localStorage.setItem(KEY_TYPE, 'nip46');
+	localStorage.setItem(KEY_BUNKER_URI, bunkerUri);
+	localStorage.setItem(KEY_RELAY, relay);
+}
+
+function clearPersistedSession(): void {
+	localStorage.removeItem(KEY_TYPE);
+	localStorage.removeItem(KEY_BUNKER_URI);
+	localStorage.removeItem(KEY_RELAY);
+}
+
+// --- Public API ---
+
+/** Returns the current signer instance (for signing operations in Phase 2/3) */
+export function getSigner(): ExtensionSigner | NostrConnectSigner | null {
+	return signer;
+}
+
+/** Returns the current signer's pubkey (hex) or null if not logged in */
+export function getSignerPubkey(): string | null {
+	return signerPubkey;
+}
+
+/**
+ * NIP-07: Log in via browser extension (window.nostr).
+ * Throws ExtensionMissingError if no extension is detected.
+ */
+export async function loginWithExtension(): Promise<void> {
+	const s = new ExtensionSigner();
+	const pubkey = await s.getPublicKey();
+	signer = s;
+	signerPubkey = pubkey;
+	persistNip07();
+}
+
+/**
+ * NIP-46: Log in by pasting a bunker:// URI.
+ * CRITICAL: calls getPublicKey() on the resolved signer — NEVER uses the URI pubkey.
+ * The URI pubkey is the remote signer's key, not the user's signing key.
+ */
+export async function loginWithBunker(uri: string): Promise<void> {
+	const s = await NostrConnectSigner.fromBunkerURI(uri, poolMethods());
+	// CRITICAL: use getPublicKey() — NEVER use the URI pubkey (it is the remote signer's key)
+	const pubkey = await s.getPublicKey();
+	signer = s;
+	signerPubkey = pubkey;
+	// Extract relay from bunker URI for persistence
+	let relay = DEFAULT_RELAY;
+	try {
+		const url = new URL(uri.replace('bunker://', 'https://'));
+		const relayParam = url.searchParams.get('relay');
+		if (relayParam) relay = relayParam;
+	} catch {
+		// ignore parse errors — use default relay
+	}
+	persistNip46(uri, relay);
+}
+
+/**
+ * NIP-46: Create a NostrConnectSigner for QR display flow (Plan 03).
+ * Does NOT call getPublicKey. The component awaits getPublicKey() after QR scan.
+ * Returns the signer instance for Plan 03's RemoteSignerTab to use.
+ */
+export function createNostrConnectSigner(relayUrl: string = DEFAULT_RELAY): NostrConnectSigner {
+	return new NostrConnectSigner({
+		relays: [relayUrl],
+		...poolMethods(),
+	});
+}
+
+/**
+ * NIP-46: Finalize QR flow login after remote signer approval.
+ * Called by RemoteSignerTab after the remote signer connects.
+ * signer must be the same NostrConnectSigner instance that generated the QR URI.
+ */
+export async function finishNostrConnectLogin(
+	s: NostrConnectSigner,
+	relayUrl: string
+): Promise<void> {
+	const pubkey = await s.getPublicKey();
+	signer = s;
+	signerPubkey = pubkey;
+	// We don't have the original bunker URI in QR flow — synthesize a reconnect URI
+	const fakeUri = `bunker://${pubkey}?relay=${encodeURIComponent(relayUrl)}`;
+	persistNip46(fakeUri, relayUrl);
+}
+
+/**
+ * Restore session from localStorage.
+ * Silently clears stored state on any error — no throws, no UI effect.
+ * Called once at app boot from +page.svelte.
+ */
+export async function restoreSession(): Promise<void> {
+	const type = localStorage.getItem(KEY_TYPE);
+	if (!type) return;
+	try {
+		if (type === 'nip07') {
+			const s = new ExtensionSigner();
+			const pubkey = await s.getPublicKey();
+			signer = s;
+			signerPubkey = pubkey;
+		} else if (type === 'nip46') {
+			const uri = localStorage.getItem(KEY_BUNKER_URI);
+			const relay = localStorage.getItem(KEY_RELAY) ?? DEFAULT_RELAY;
+			if (!uri) throw new Error('missing bunker uri');
+			const s = await NostrConnectSigner.fromBunkerURI(uri, poolMethods());
+			const pubkey = await s.getPublicKey();
+			signer = s;
+			signerPubkey = pubkey;
+		}
+	} catch (err) {
+		// Silent fallback: clear storage, stay logged out (per RESEARCH.md Pitfall 2)
+		console.warn('[auth] restoreSession failed, clearing stored session:', err);
+		clearPersistedSession();
+		signer = null;
+		signerPubkey = null;
+	}
+}
+
+/**
+ * Log out the current user.
+ * Closes NIP-46 connection if active, clears all auth state and localStorage.
+ */
+export function logout(): void {
+	if (signer instanceof NostrConnectSigner) {
+		signer.close();
+	}
+	signer = null;
+	signerPubkey = null;
+	clearPersistedSession();
+}

--- a/src/lib/components/LoginModal.svelte
+++ b/src/lib/components/LoginModal.svelte
@@ -1,0 +1,70 @@
+<script lang="ts">
+	import ExtensionTab from './LoginModal/ExtensionTab.svelte';
+	import RemoteSignerTab from './LoginModal/RemoteSignerTab.svelte';
+
+	let { onClose }: { onClose: () => void } = $props();
+
+	type Tab = 'extension' | 'remote';
+	let activeTab = $state<Tab>('extension');
+
+	function handleKeydown(e: KeyboardEvent) {
+		if (e.key === 'Escape') onClose();
+	}
+</script>
+
+<svelte:window onkeydown={handleKeydown} />
+
+<!-- Backdrop -->
+<div
+	class="fixed inset-0 z-50 flex items-center justify-center bg-background/80 backdrop-blur-sm"
+	role="presentation"
+	onclick={onClose}
+>
+	<!-- Modal panel — stop click propagation so backdrop click doesn't fire inside -->
+	<div
+		class="relative w-full max-w-sm rounded-xl border border-border bg-card p-6 shadow-xl"
+		role="dialog"
+		aria-modal="true"
+		aria-label="Log In"
+		tabindex="-1"
+		onclick={(e) => e.stopPropagation()}
+		onkeydown={(e) => e.key === 'Escape' && onClose()}
+	>
+		<div class="mb-4 flex items-center justify-between">
+			<h2 class="text-xl font-semibold text-foreground">Log In</h2>
+			<button
+				class="text-muted-foreground hover:text-foreground"
+				onclick={onClose}
+				aria-label="Close"
+			>&#x2715;</button>
+		</div>
+
+		<!-- Tab bar -->
+		<div class="mb-6 flex gap-2 border-b border-border" role="tablist">
+			<button
+				class="min-h-[44px] px-3 pb-2 text-sm font-medium transition-colors
+				       {activeTab === 'extension'
+				         ? 'border-b-2 border-primary text-primary'
+				         : 'text-muted-foreground hover:text-foreground'}"
+				role="tab"
+				aria-selected={activeTab === 'extension'}
+				onclick={() => (activeTab = 'extension')}
+			>Extension</button>
+			<button
+				class="min-h-[44px] px-3 pb-2 text-sm font-medium transition-colors
+				       {activeTab === 'remote'
+				         ? 'border-b-2 border-primary text-primary'
+				         : 'text-muted-foreground hover:text-foreground'}"
+				role="tab"
+				aria-selected={activeTab === 'remote'}
+				onclick={() => (activeTab = 'remote')}
+			>Remote Signer</button>
+		</div>
+
+		{#if activeTab === 'extension'}
+			<ExtensionTab {onClose} />
+		{:else}
+			<RemoteSignerTab {onClose} />
+		{/if}
+	</div>
+</div>

--- a/src/lib/components/LoginModal/ExtensionTab.svelte
+++ b/src/lib/components/LoginModal/ExtensionTab.svelte
@@ -1,0 +1,55 @@
+<script lang="ts">
+	import { loginWithExtension } from '$lib/auth.svelte';
+	import LoadingSpinner from '$lib/components/LoadingSpinner.svelte';
+
+	let { onClose }: { onClose: () => void } = $props();
+
+	const hasExtension = $derived(
+		typeof window !== 'undefined' && typeof (window as Window & { nostr?: unknown }).nostr !== 'undefined'
+	);
+	let connecting = $state(false);
+	let error = $state<string | null>(null);
+
+	async function handleConnect() {
+		connecting = true;
+		error = null;
+		try {
+			await loginWithExtension();
+			onClose();
+		} catch (e) {
+			const msg = e instanceof Error ? e.message : String(e);
+			if (msg.toLowerCase().includes('missing') || msg.toLowerCase().includes('not found')) {
+				error = 'No Nostr extension detected. Install Alby or nos2x to continue.';
+			} else if (msg.toLowerCase().includes('denied') || msg.toLowerCase().includes('rejected')) {
+				error = 'Extension denied the request. Try again.';
+			} else {
+				error = msg;
+			}
+		} finally {
+			connecting = false;
+		}
+	}
+</script>
+
+{#if connecting}
+	<LoadingSpinner message="Connecting..." />
+{:else}
+	<div class="flex flex-col gap-4">
+		<button
+			class="w-full rounded-lg bg-primary px-4 py-2 text-sm font-medium text-primary-foreground
+			       hover:opacity-80 disabled:cursor-not-allowed disabled:opacity-50"
+			onclick={handleConnect}
+			disabled={!hasExtension}
+			aria-disabled={!hasExtension}
+			title={hasExtension ? undefined : 'No extension detected'}
+		>Connect Extension</button>
+
+		{#if !hasExtension}
+			<p class="text-xs text-muted-foreground">No extension detected</p>
+		{/if}
+
+		{#if error}
+			<p class="text-sm text-destructive">{error}</p>
+		{/if}
+	</div>
+{/if}

--- a/src/lib/components/LoginModal/RemoteSignerTab.svelte
+++ b/src/lib/components/LoginModal/RemoteSignerTab.svelte
@@ -1,0 +1,150 @@
+<script lang="ts">
+	import { onMount } from 'svelte';
+	import { generate } from 'lean-qr';
+	import { createNostrConnectSigner, loginWithBunker, finishNostrConnectLogin } from '$lib/auth.svelte';
+	import type { NostrConnectSigner } from 'applesauce-signers';
+	import LoadingSpinner from '$lib/components/LoadingSpinner.svelte';
+
+	let { onClose }: { onClose: () => void } = $props();
+
+	const DEFAULT_RELAY = 'wss://bucket.coracle.social';
+
+	let relayUrl = $state(DEFAULT_RELAY);
+	let bunkerInput = $state('');
+	let connecting = $state(false);
+	let connectError = $state<string | null>(null);
+	let canvasEl = $state<HTMLCanvasElement | null>(null);
+
+	// Active signer used for QR flow — recreated when relay changes
+	let nostrConnectSigner = $state<NostrConnectSigner | null>(null);
+	let nostrConnectUri = $state('');
+
+	function buildQrSigner(relay: string) {
+		nostrConnectSigner = createNostrConnectSigner(relay);
+		nostrConnectUri = nostrConnectSigner.getNostrConnectURI({ name: 'npub-home' });
+		if (canvasEl) renderQr(canvasEl, nostrConnectUri);
+	}
+
+	function renderQr(canvas: HTMLCanvasElement, uri: string) {
+		generate(uri).toCanvas(canvas, {
+			on: [0x8b, 0x5c, 0xf6, 0xff], // primary purple rgba
+			off: [0x00, 0x00, 0x00, 0x00], // transparent
+			pad: 2,
+		});
+	}
+
+	onMount(() => {
+		buildQrSigner(relayUrl);
+	});
+
+	// $effect re-renders QR when canvasEl is bound after mount
+	$effect(() => {
+		if (canvasEl && nostrConnectUri) {
+			renderQr(canvasEl, nostrConnectUri);
+		}
+	});
+
+	function handleRelayInput() {
+		buildQrSigner(relayUrl.trim() || DEFAULT_RELAY);
+	}
+
+	async function handleBunkerConnect() {
+		if (!bunkerInput.trim()) return;
+		connecting = true;
+		connectError = null;
+		try {
+			await loginWithBunker(bunkerInput.trim());
+			onClose();
+		} catch (e) {
+			const msg = e instanceof Error ? e.message : String(e);
+			if (msg.toLowerCase().includes('timeout')) {
+				connectError = 'Connection timed out. Check the relay and try again.';
+			} else if (msg.toLowerCase().includes('invalid') || msg.toLowerCase().includes('uri')) {
+				connectError = 'Invalid bunker URI. Paste a valid bunker://... address.';
+			} else {
+				connectError = msg;
+			}
+		} finally {
+			connecting = false;
+		}
+	}
+
+	// QR flow: begin waiting for approval when user clicks "Waiting for scan"
+	// User scans the QR code; remote signer sends approval to our relay
+	async function handleQrApproval() {
+		if (!nostrConnectSigner) return;
+		connecting = true;
+		connectError = null;
+		try {
+			await finishNostrConnectLogin(nostrConnectSigner, relayUrl);
+			onClose();
+		} catch (e) {
+			const msg = e instanceof Error ? e.message : String(e);
+			connectError = msg.toLowerCase().includes('timeout')
+				? 'Connection timed out. Check the relay and try again.'
+				: msg;
+		} finally {
+			connecting = false;
+		}
+	}
+</script>
+
+{#if connecting}
+	<LoadingSpinner message="Waiting for approval..." />
+{:else}
+	<div class="flex flex-col gap-4">
+		<!-- Relay field -->
+		<div class="flex flex-col gap-1">
+			<label for="relay-input" class="text-xs text-muted-foreground">Relay</label>
+			<input
+				id="relay-input"
+				type="url"
+				bind:value={relayUrl}
+				oninput={handleRelayInput}
+				placeholder="wss://bucket.coracle.social"
+				class="w-full rounded-md border border-border bg-secondary px-3 py-2 text-sm
+				       text-foreground placeholder-muted-foreground
+				       focus:outline-none focus:ring-2 focus:ring-primary"
+			/>
+		</div>
+
+		<!-- QR code canvas -->
+		<div class="flex flex-col items-center gap-2">
+			<p class="text-xs text-muted-foreground">Scan with your signer app</p>
+			<canvas
+				bind:this={canvasEl}
+				aria-label="NIP-46 connection QR code"
+				style="image-rendering: pixelated; width: 200px; height: 200px;"
+				class="rounded"
+			></canvas>
+			<button
+				class="text-xs text-primary underline hover:opacity-80"
+				onclick={handleQrApproval}
+			>Waiting for scan... (click to confirm)</button>
+		</div>
+
+		<!-- Bunker URI paste -->
+		<div class="flex flex-col gap-1">
+			<label for="bunker-input" class="text-xs text-muted-foreground">Bunker URI</label>
+			<input
+				id="bunker-input"
+				type="text"
+				bind:value={bunkerInput}
+				placeholder="bunker://..."
+				class="w-full rounded-md border border-border bg-secondary px-3 py-2 text-sm
+				       text-foreground placeholder-muted-foreground
+				       focus:outline-none focus:ring-2 focus:ring-primary"
+			/>
+			<button
+				class="mt-1 w-full rounded-lg bg-primary px-4 py-2 text-sm font-medium
+				       text-primary-foreground hover:opacity-80 disabled:opacity-50"
+				onclick={handleBunkerConnect}
+				disabled={!bunkerInput.trim()}
+			>Connect</button>
+		</div>
+
+		{#if connectError}
+			<p class="text-sm text-destructive">{connectError}</p>
+		{/if}
+	</div>
+{/if}

--- a/src/lib/components/NsiteList.svelte
+++ b/src/lib/components/NsiteList.svelte
@@ -1,16 +1,50 @@
 <script lang="ts">
 	import type { NsiteEntry } from '$lib/nostr/loaders';
-	import { buildSiteUrl, buildSnapshotUrl } from '$lib/nostr/bootstrap';
+	import type { RelayPool } from 'applesauce-relay';
+	import type { EventSigner } from 'applesauce-core/event-factory';
+	import { EventFactory } from 'applesauce-core/event-factory';
+	import { buildSiteUrl, buildSnapshotUrl, BOOTSTRAP_RELAYS } from '$lib/nostr/bootstrap';
+
+	// --- Props ---
 
 	let {
 		nsites,
 		host,
-		pubkey
+		pubkey,
+		isOwner = false,
+		signer,
+		pool,
+		writeRelays = []
 	}: {
 		nsites: NsiteEntry[];
 		host: string;
 		pubkey: string;
+		isOwner?: boolean;
+		signer?: EventSigner;
+		pool?: RelayPool;
+		writeRelays?: string[];
 	} = $props();
+
+	// --- Types ---
+
+	type RowMode = 'view' | 'editing' | 'confirm-delete' | 'saving' | 'deleting' | 'deleted';
+
+	// --- Per-entry row state ---
+
+	let rowModes = $state<Record<string, RowMode>>({});
+	let editValues = $state<Record<string, { title: string; description: string }>>({});
+	let errorMessages = $state<Record<string, string>>({});
+	let deletedKeys = $state<Set<string>>(new Set());
+
+	// --- Helpers ---
+
+	function nsiteKey(nsite: NsiteEntry): string {
+		return nsite.slug ?? '__root__';
+	}
+
+	function getMode(nsite: NsiteEntry): RowMode {
+		return rowModes[nsiteKey(nsite)] ?? 'view';
+	}
 
 	function formatDate(timestamp: number): string {
 		return new Date(timestamp * 1000).toLocaleDateString(undefined, {
@@ -23,6 +57,97 @@
 	function siteLabel(nsite: NsiteEntry): string {
 		return nsite.title || nsite.slug || 'Root site';
 	}
+
+	// --- Edit handlers ---
+
+	function openEdit(nsite: NsiteEntry) {
+		const key = nsiteKey(nsite);
+		editValues = {
+			...editValues,
+			[key]: { title: nsite.title ?? nsite.slug ?? '', description: nsite.description ?? '' }
+		};
+		rowModes = { ...rowModes, [key]: 'editing' };
+		errorMessages = { ...errorMessages, [key]: '' };
+	}
+
+	function cancelEdit(nsite: NsiteEntry) {
+		const key = nsiteKey(nsite);
+		rowModes = { ...rowModes, [key]: 'view' };
+		errorMessages = { ...errorMessages, [key]: '' };
+	}
+
+	async function saveEdit(nsite: NsiteEntry) {
+		if (!nsite.sourceEvent || !signer || !pool) return;
+		const key = nsiteKey(nsite);
+		rowModes = { ...rowModes, [key]: 'saving' };
+		errorMessages = { ...errorMessages, [key]: '' };
+		try {
+			const factory = new EventFactory({ signer });
+			const vals = editValues[key];
+			const template = await factory.modify(nsite.sourceEvent, (draft) => {
+				const otherTags = draft.tags.filter((t) => t[0] !== 'title' && t[0] !== 'description');
+				return {
+					...draft,
+					tags: [
+						...otherTags,
+						...(vals.title ? [['title', vals.title]] : []),
+						...(vals.description ? [['description', vals.description]] : [])
+					]
+				};
+			});
+			const signed = await factory.sign(template);
+			const targets = writeRelays.length > 0 ? writeRelays : BOOTSTRAP_RELAYS;
+			await pool.publish(targets, signed);
+			rowModes = { ...rowModes, [key]: 'view' };
+		} catch {
+			rowModes = { ...rowModes, [key]: 'editing' };
+			errorMessages = {
+				...errorMessages,
+				[key]: 'Failed to save. Check your connection and try again.'
+			};
+		}
+	}
+
+	// --- Delete handlers ---
+
+	function openConfirmDelete(nsite: NsiteEntry) {
+		const key = nsiteKey(nsite);
+		rowModes = { ...rowModes, [key]: 'confirm-delete' };
+		errorMessages = { ...errorMessages, [key]: '' };
+	}
+
+	function cancelDelete(nsite: NsiteEntry) {
+		const key = nsiteKey(nsite);
+		rowModes = { ...rowModes, [key]: 'view' };
+		errorMessages = { ...errorMessages, [key]: '' };
+	}
+
+	async function requestDeletion(nsite: NsiteEntry) {
+		if (!nsite.sourceEvent || !signer || !pool) return;
+		const key = nsiteKey(nsite);
+		rowModes = { ...rowModes, [key]: 'deleting' };
+		errorMessages = { ...errorMessages, [key]: '' };
+		try {
+			const factory = new EventFactory({ signer });
+			// Dynamic import avoids vi.mock hoisting temporal dead zone in tests
+			const { setDeleteEvents } = await import('applesauce-core/operations/delete');
+			const template = await factory.build(
+				{ kind: 5, content: '' },
+				setDeleteEvents([nsite.sourceEvent!])
+			);
+			const signed = await factory.sign(template);
+			const targets = writeRelays.length > 0 ? writeRelays : BOOTSTRAP_RELAYS;
+			await pool.publish(targets, signed);
+			rowModes = { ...rowModes, [key]: 'deleted' };
+			deletedKeys = new Set([...deletedKeys, key]);
+		} catch {
+			rowModes = { ...rowModes, [key]: 'confirm-delete' };
+			errorMessages = {
+				...errorMessages,
+				[key]: 'Failed to request deletion. Check your connection and try again.'
+			};
+		}
+	}
 </script>
 
 <div class="px-6 pb-8">
@@ -32,13 +157,104 @@
 		<p class="text-center text-sm text-muted-foreground opacity-60">No nsites published yet</p>
 	{:else}
 		<div class="grid gap-3">
-			{#each nsites as nsite}
-				{#if nsite.versions.length === 0}
-					<a
-						href={buildSiteUrl(host, pubkey, nsite.slug)}
+			{#each nsites as nsite (nsiteKey(nsite))}
+				{@const key = nsiteKey(nsite)}
+				{@const mode = getMode(nsite)}
+
+				{#if deletedKeys.has(key)}
+					<!-- Deletion requested indicator -->
+					<div
+						class="rounded-lg border border-border bg-card px-4 py-3 text-xs text-muted-foreground opacity-60"
+					>
+						Deletion requested
+					</div>
+				{:else if mode === 'editing' || mode === 'saving'}
+					<!-- Inline edit form -->
+					<div class="rounded-lg border border-border bg-card px-4 py-3">
+						<div class="flex flex-col gap-2">
+							<input
+								type="text"
+								class="border border-border rounded px-2 py-1 text-sm bg-background text-foreground"
+								placeholder="Name"
+								value={editValues[key]?.title ?? ''}
+								oninput={(e) => {
+									editValues = {
+										...editValues,
+										[key]: {
+											...editValues[key],
+											title: (e.target as HTMLInputElement).value
+										}
+									};
+								}}
+								disabled={mode === 'saving'}
+							/>
+							<textarea
+								class="border border-border rounded px-2 py-1 text-sm bg-background text-foreground"
+								placeholder="Description"
+								rows={2}
+								value={editValues[key]?.description ?? ''}
+								oninput={(e) => {
+									editValues = {
+										...editValues,
+										[key]: {
+											...editValues[key],
+											description: (e.target as HTMLTextAreaElement).value
+										}
+									};
+								}}
+								disabled={mode === 'saving'}
+							></textarea>
+							<div class="flex items-center gap-2">
+								<button
+									class="text-xs bg-primary text-primary-foreground px-2 py-1 rounded disabled:opacity-50"
+									onclick={() => saveEdit(nsite)}
+									disabled={mode === 'saving'}
+								>
+									{mode === 'saving' ? 'Saving...' : 'Save'}
+								</button>
+								<button
+									class="text-xs text-muted-foreground underline ml-2"
+									onclick={() => cancelEdit(nsite)}
+									disabled={mode === 'saving'}
+								>
+									Cancel
+								</button>
+							</div>
+							{#if errorMessages[key]}
+								<p class="text-xs text-destructive">{errorMessages[key]}</p>
+							{/if}
+						</div>
+					</div>
+				{:else if mode === 'confirm-delete' || mode === 'deleting'}
+					<!-- Inline delete confirmation -->
+					<div class="rounded-lg border border-border bg-card px-4 py-3">
+						<p class="text-sm text-foreground mb-2">Request deletion? This is best-effort.</p>
+						<div class="flex items-center gap-2">
+							<button
+								class="text-xs bg-destructive text-destructive-foreground px-2 py-1 rounded disabled:opacity-50"
+								onclick={() => requestDeletion(nsite)}
+								disabled={mode === 'deleting'}
+							>
+								{mode === 'deleting' ? 'Deleting...' : 'Delete'}
+							</button>
+							<button
+								class="text-xs text-muted-foreground underline ml-2"
+								onclick={() => cancelDelete(nsite)}
+								disabled={mode === 'deleting'}
+							>
+								Cancel
+							</button>
+						</div>
+						{#if errorMessages[key]}
+							<p class="text-xs text-destructive mt-1">{errorMessages[key]}</p>
+						{/if}
+					</div>
+				{:else if nsite.versions.length === 0}
+					<!-- View mode: no versions — simple row with optional management icons -->
+					<div
 						class="group flex items-center justify-between rounded-lg border border-border bg-card px-4 py-3 transition hover:border-primary/50 hover:bg-secondary"
 					>
-						<div>
+						<a href={buildSiteUrl(host, pubkey, nsite.slug)} class="flex-1 min-w-0">
 							<div class="flex flex-wrap items-center gap-x-2 gap-y-1">
 								<span class="font-medium text-foreground group-hover:text-primary">{siteLabel(nsite)}</span>
 								{#if nsite.slug && nsite.title}
@@ -52,10 +268,27 @@
 							{#if nsite.description}
 								<p class="mt-1 text-xs text-muted-foreground">{nsite.description}</p>
 							{/if}
+						</a>
+						<div class="flex items-center gap-1 ml-2">
+							{#if isOwner}
+								<button
+									class="ml-2 text-muted-foreground hover:text-foreground text-sm"
+									onclick={() => openEdit(nsite)}
+									title="Edit nsite"
+									aria-label="Edit nsite"
+								>&#x270F;</button>
+								<button
+									class="ml-2 text-muted-foreground hover:text-foreground text-sm"
+									onclick={() => openConfirmDelete(nsite)}
+									title="Delete nsite"
+									aria-label="Delete nsite"
+								>&#x1F5D1;</button>
+							{/if}
+							<span class="text-muted-foreground transition group-hover:text-primary">&rarr;</span>
 						</div>
-						<span class="text-muted-foreground transition group-hover:text-primary">&rarr;</span>
-					</a>
+					</div>
 				{:else}
+					<!-- View mode: has versions — expandable details with management icons -->
 					<details class="overflow-hidden rounded-lg border border-border bg-card open:border-primary/50">
 						<summary class="flex cursor-pointer list-none items-center justify-between gap-4 px-4 py-3">
 							<div>
@@ -73,9 +306,25 @@
 									<p class="mt-1 text-xs text-muted-foreground">{nsite.description}</p>
 								{/if}
 							</div>
-							<div class="text-right text-xs text-muted-foreground">
-								<p>{nsite.versions.length} version{nsite.versions.length === 1 ? '' : 's'}</p>
-								<p class="mt-1">Expand</p>
+							<div class="flex items-center gap-2">
+								{#if isOwner}
+									<button
+										class="text-muted-foreground hover:text-foreground text-sm"
+										onclick={(e) => { e.preventDefault(); openEdit(nsite); }}
+										title="Edit nsite"
+										aria-label="Edit nsite"
+									>&#x270F;</button>
+									<button
+										class="text-muted-foreground hover:text-foreground text-sm"
+										onclick={(e) => { e.preventDefault(); openConfirmDelete(nsite); }}
+										title="Delete nsite"
+										aria-label="Delete nsite"
+									>&#x1F5D1;</button>
+								{/if}
+								<div class="text-right text-xs text-muted-foreground">
+									<p>{nsite.versions.length} version{nsite.versions.length === 1 ? '' : 's'}</p>
+									<p class="mt-1">Expand</p>
+								</div>
 							</div>
 						</summary>
 

--- a/src/lib/components/OwnerBadge.svelte
+++ b/src/lib/components/OwnerBadge.svelte
@@ -1,0 +1,17 @@
+<script lang="ts">
+	import { logout } from '$lib/auth.svelte';
+
+	let { ontheme }: { ontheme?: () => void } = $props();
+</script>
+
+<div class="flex items-center gap-2 px-4 py-2 text-sm font-semibold text-primary">
+	Logged in as owner
+	<button
+		class="text-xs font-normal text-muted-foreground underline hover:text-foreground"
+		onclick={() => ontheme?.()}
+	>Theme</button>
+	<button
+		class="text-xs font-normal text-muted-foreground underline hover:text-foreground"
+		onclick={logout}
+	>Log out</button>
+</div>

--- a/src/lib/components/ThemePicker.svelte
+++ b/src/lib/components/ThemePicker.svelte
@@ -1,0 +1,391 @@
+<script lang="ts">
+	import { onMount } from 'svelte';
+	import type { NostrEvent } from 'nostr-tools';
+	import type { RelayPool } from 'applesauce-relay';
+	import type { EventSigner } from 'applesauce-core/event-factory';
+	import { EventFactory } from 'applesauce-core/event-factory';
+	import { parseThemeDefinition, decodeNeventInput, applyTheme, clearTheme } from '$lib/theme';
+	import type { ActiveProfileTheme } from '$lib/theme';
+	import { BOOTSTRAP_RELAYS } from '$lib/nostr/bootstrap';
+	import LoadingSpinner from '$lib/components/LoadingSpinner.svelte';
+
+	// --- Types ---
+
+	interface ThemeEntry {
+		event: NostrEvent;
+		parsed: ActiveProfileTheme;
+		name: string;
+	}
+
+	// --- Props ---
+
+	let {
+		signer,
+		pool,
+		pubkey,
+		writeRelays,
+		onclose,
+	}: {
+		signer: EventSigner;
+		pool: RelayPool;
+		pubkey: string;
+		writeRelays: string[];
+		onclose: () => void;
+	} = $props();
+
+	// --- Curated themes (surveyed from public relays 2026-04-09) ---
+	// naddr references for real kind 36767 events found on wss://relay.damus.io, wss://nos.lol, wss://purplepag.es
+
+	const CURATED_THEMES: { ref: string; name: string }[] = [
+		{
+			ref: 'naddr1qqfk6etyd96x2unjv9hx2ctw94j8yetpd5pzqe9l4x4lled335rnrmk40vupwwku9w5fh7ruz6x6jpgh7qs7wg44qvzqqqy0nutxymdp',
+			name: 'Mediterranean Dream',
+		},
+		{
+			ref: 'naddr1qqrxxmmnd4hhxq3q8ams6ewn5aj2n3wt2qawzglx9mr4nzksxhvrdc4gzrecw7n5tvjqxpqqqz8e7d40hv9',
+			name: 'Cosmos',
+		},
+		{
+			ref: 'naddr1qqzhxmrpw3jsyg8wd6sn4w07t39x36hekx35lcq55e45qytu2rhz5c20fndftxmwwspsgqqq370s5uz4q6',
+			name: 'Slate',
+		},
+		{
+			ref: 'naddr1qqyksctvd3hhwet9dcpzqprpljlvcnpnw3pejvkkhrc3y6wvmd7vjuad0fg2ud3dky66gaxaqvzqqqy0nu5vdhv0',
+			name: 'Halloween',
+		},
+		{
+			ref: 'naddr1qqrkx6tjvd6kjaqzypnxw52cucecl6ylmfqcus4qhu4852cny5zd6drlq9dp39cmv3zrqqcyqqqgl8cwulyk4',
+			name: 'Circuit',
+		},
+		{
+			ref: 'naddr1qq9kwun9v4hz6mrfva58gq3q4rg4vrt2v374q95ezeeydu3hkdhmzglcj950mggacap4x0lv0gyqxpqqqz8e7uzpzg9',
+			name: 'Green Light',
+		},
+		{
+			ref: 'naddr1qq9kummjw35z6am0daj8xq3qjawsh2wrjk25urgx4qq65fam67nrrkdf4zjxrhcezv5v69g9gxwqxpqqqz8e7tt5wdw',
+			name: 'North Woods',
+		},
+		{
+			ref: 'naddr1qqrhvetwv96x7uszyrpt5ppu4xmmzw6azwp2sxpe7uyk4s4s49536w8207td5ys8k8ktuqcyqqqgl8cgqvfk0',
+			name: 'Venator',
+		},
+	];
+
+	// --- State ---
+
+	let themes = $state<ThemeEntry[]>([]);
+	let loading = $state(true);
+	let selectedEvent = $state<NostrEvent | null>(null);
+	let neventInput = $state('');
+	let neventError = $state<string | null>(null);
+	let neventLoading = $state(false);
+	let publishing = $state(false);
+	let publishError = $state<string | null>(null);
+
+	// --- Lifecycle ---
+
+	onMount(() => {
+		const subs: { unsubscribe(): void }[] = [];
+		const seen = new Set<string>();
+
+		// Fetch all curated themes concurrently
+		CURATED_THEMES.forEach(({ ref }) => {
+			const decoded = decodeNeventInput(ref);
+			if (!decoded) return;
+
+			// For naddr (id is empty string), skip — naddr needs kind+pubkey+d-tag filter
+			// which requires nip19.decode naddr handling beyond what decodeNeventInput returns.
+			// Curated entries are provided as naddr refs; use fallback event ID approach instead.
+			if (!decoded.id) return;
+
+			const relays = decoded.relays.length > 0 ? decoded.relays : BOOTSTRAP_RELAYS;
+			const sub = pool.req(relays, [{ ids: [decoded.id], kinds: [36767] }]).subscribe((msg) => {
+				if (msg === 'EOSE') return;
+				if (seen.has(msg.id)) return;
+				seen.add(msg.id);
+				const parsed = parseThemeDefinition(msg);
+				if (!parsed) return;
+				const titleTag = msg.tags.find((t) => t[0] === 'title')?.[1];
+				const dTag = msg.tags.find((t) => t[0] === 'd')?.[1];
+				const name = titleTag ?? dTag ?? 'Unnamed Theme';
+				themes = [...themes, { event: msg, parsed, name }];
+			});
+			subs.push(sub);
+		});
+
+		// Fetch curated themes by naddr (kind+pubkey+d-tag) for entries with naddr refs
+		// Parse the naddr refs directly using nip19 to get kind/pubkey/d-tag filters
+		import('nostr-tools').then(({ nip19 }) => {
+			CURATED_THEMES.forEach(({ ref, name: curatedName }) => {
+				try {
+					const decoded = nip19.decode(ref);
+					if (decoded.type !== 'naddr') return;
+					const { kind, pubkey: authorPubkey, identifier, relays: naddrRelays } = decoded.data;
+					const relays = (naddrRelays && naddrRelays.length > 0) ? naddrRelays : BOOTSTRAP_RELAYS;
+					const filter = [{ kinds: [kind], authors: [authorPubkey], '#d': [identifier] }];
+					const sub = pool.req(relays, filter).subscribe((msg) => {
+						if (msg === 'EOSE') return;
+						if (seen.has(msg.id)) return;
+						seen.add(msg.id);
+						const parsed = parseThemeDefinition(msg);
+						if (!parsed) return;
+						const titleTag = msg.tags.find((t) => t[0] === 'title')?.[1];
+						const dTag = msg.tags.find((t) => t[0] === 'd')?.[1];
+						const name = titleTag ?? dTag ?? curatedName;
+						themes = [...themes, { event: msg, parsed, name }];
+					});
+					subs.push(sub);
+				} catch {
+					// invalid naddr — skip
+				}
+			});
+		});
+
+		// Set loading = false after timeout (covers EOSE from all relays)
+		const timer = setTimeout(() => { loading = false; }, 3000);
+
+		return () => {
+			subs.forEach((s) => s.unsubscribe());
+			clearTimeout(timer);
+		};
+	});
+
+	// --- Handlers ---
+
+	function selectTheme(entry: ThemeEntry) {
+		selectedEvent = entry.event;
+		applyTheme(entry.parsed);
+	}
+
+	function handleClose() {
+		clearTheme();
+		// +page.svelte's themeSub will re-apply the stored kind 16767 theme if any
+		onclose();
+	}
+
+	async function addCustomTheme() {
+		neventError = null;
+		const decoded = decodeNeventInput(neventInput.trim());
+		if (!decoded) {
+			neventError = 'Could not fetch theme. Check the nevent reference and try again.';
+			return;
+		}
+		neventLoading = true;
+		try {
+			if (decoded.id) {
+				// nevent or note: fetch by event ID
+				const relays = decoded.relays.length > 0 ? decoded.relays : BOOTSTRAP_RELAYS;
+				await new Promise<void>((resolve, reject) => {
+					const sub = pool.req(relays, [{ ids: [decoded.id], kinds: [36767] }]).subscribe((msg) => {
+						if (msg === 'EOSE') { sub.unsubscribe(); reject(new Error('not found')); return; }
+						if (msg.kind !== 36767) { sub.unsubscribe(); reject(new Error('not a theme')); return; }
+						const parsed = parseThemeDefinition(msg);
+						if (!parsed) { sub.unsubscribe(); reject(new Error('invalid theme')); return; }
+						const titleTag = msg.tags.find((t) => t[0] === 'title')?.[1];
+						const dTag = msg.tags.find((t) => t[0] === 'd')?.[1];
+						const name = titleTag ?? dTag ?? 'Unnamed Theme';
+						themes = [...themes, { event: msg, parsed, name }];
+						neventInput = '';
+						sub.unsubscribe();
+						resolve();
+					});
+				});
+			} else {
+				// naddr: fetch by kind+pubkey+d-tag
+				const { nip19 } = await import('nostr-tools');
+				const naddrDecoded = nip19.decode(neventInput.trim());
+				if (naddrDecoded.type !== 'naddr') {
+					neventError = 'Could not fetch theme. Check the nevent reference and try again.';
+					neventLoading = false;
+					return;
+				}
+				const { kind, pubkey: authorPubkey, identifier, relays: naddrRelays } = naddrDecoded.data;
+				const relays = (naddrRelays && naddrRelays.length > 0) ? naddrRelays : BOOTSTRAP_RELAYS;
+				await new Promise<void>((resolve, reject) => {
+					const sub = pool.req(relays, [{ kinds: [kind], authors: [authorPubkey], '#d': [identifier] }]).subscribe((msg) => {
+						if (msg === 'EOSE') { sub.unsubscribe(); reject(new Error('not found')); return; }
+						if (msg.kind !== 36767) { sub.unsubscribe(); reject(new Error('not a theme')); return; }
+						const parsed = parseThemeDefinition(msg);
+						if (!parsed) { sub.unsubscribe(); reject(new Error('invalid theme')); return; }
+						const titleTag = msg.tags.find((t) => t[0] === 'title')?.[1];
+						const dTag = msg.tags.find((t) => t[0] === 'd')?.[1];
+						const name = titleTag ?? dTag ?? 'Unnamed Theme';
+						themes = [...themes, { event: msg, parsed, name }];
+						neventInput = '';
+						sub.unsubscribe();
+						resolve();
+					});
+				});
+			}
+		} catch {
+			neventError = 'Could not fetch theme. Check the nevent reference and try again.';
+		} finally {
+			neventLoading = false;
+		}
+	}
+
+	async function applySelectedTheme() {
+		if (!selectedEvent) return;
+		publishing = true;
+		publishError = null;
+		try {
+			// Copy c/f/bg tags directly from source event — avoids hex/HSL round-trip (Pitfall 1)
+			const sourceTags = selectedEvent.tags.filter(
+				(t) => t[0] === 'c' || t[0] === 'f' || t[0] === 'bg'
+			);
+			// Include a back-reference to the source kind 36767 if it has a d-tag
+			const dTag = selectedEvent.tags.find((t) => t[0] === 'd')?.[1];
+			const aTag: string[][] = dTag
+				? [['a', `36767:${selectedEvent.pubkey}:${dTag}`, '']]
+				: [];
+			const factory = new EventFactory({ signer });
+			const template = await factory.build({
+				kind: 16767,
+				content: '',
+				tags: [
+					...sourceTags,
+					['alt', 'Active profile theme'],
+					...aTag,
+				],
+			});
+			const signed = await factory.sign(template);
+			const targets = writeRelays.length > 0 ? writeRelays : BOOTSTRAP_RELAYS;
+			await pool.publish(targets, signed);
+			onclose();
+		} catch {
+			publishError = 'Failed to publish theme. Check your connection and try again.';
+		} finally {
+			publishing = false;
+		}
+	}
+</script>
+
+<svelte:window onkeydown={(e) => e.key === 'Escape' && handleClose()} />
+
+<!-- Backdrop -->
+<div
+	class="fixed inset-0 z-50 flex items-center justify-center bg-background/80 backdrop-blur-sm"
+	role="presentation"
+	onclick={handleClose}
+>
+	<!-- Modal panel -->
+	<div
+		class="relative w-full max-w-md rounded-xl border border-border bg-card p-6 shadow-xl"
+		role="dialog"
+		aria-modal="true"
+		aria-label="Pick a Theme"
+		tabindex="-1"
+		onclick={(e) => e.stopPropagation()}
+		onkeydown={(e) => e.key === 'Escape' && handleClose()}
+	>
+		<!-- Header -->
+		<div class="mb-4 flex items-center justify-between">
+			<h2 class="text-xl font-semibold text-foreground">Pick a Theme</h2>
+			<button
+				class="text-muted-foreground hover:text-foreground"
+				onclick={handleClose}
+				aria-label="Close"
+			>&#x2715;</button>
+		</div>
+
+		<!-- Theme grid -->
+		{#if loading && themes.length === 0}
+			<LoadingSpinner message="Loading themes..." />
+		{:else if !loading && themes.length === 0}
+			<div class="py-8 text-center">
+				<p class="text-sm font-medium text-foreground">No themes found</p>
+				<p class="mt-1 text-xs text-muted-foreground">Could not load themes from relays. Check your connection and refresh.</p>
+			</div>
+		{:else}
+			<div class="grid grid-cols-2 gap-3">
+				{#each themes as entry (entry.event.id)}
+					{@const bgHex = entry.event.tags.find((t) => t[0] === 'c' && t[2] === 'background')?.[1] ?? '#888888'}
+					{@const textHex = entry.event.tags.find((t) => t[0] === 'c' && t[2] === 'text')?.[1] ?? '#888888'}
+					{@const primaryHex = entry.event.tags.find((t) => t[0] === 'c' && t[2] === 'primary')?.[1] ?? '#888888'}
+					<button
+						class="rounded-lg border p-3 text-left transition-colors
+							{selectedEvent?.id === entry.event.id
+								? 'border-primary ring-2 ring-primary bg-card'
+								: 'border-border bg-card hover:border-primary/50 hover:bg-secondary'}"
+						aria-pressed={selectedEvent?.id === entry.event.id}
+						onclick={() => selectTheme(entry)}
+					>
+						<div class="mb-2 flex gap-2">
+							<span
+								class="h-5 w-5 rounded-full"
+								style="background-color: {bgHex}"
+								aria-hidden="true"
+							></span>
+							<span
+								class="h-5 w-5 rounded-full"
+								style="background-color: {textHex}"
+								aria-hidden="true"
+							></span>
+							<span
+								class="h-5 w-5 rounded-full"
+								style="background-color: {primaryHex}"
+								aria-hidden="true"
+							></span>
+						</div>
+						<p class="text-sm font-medium text-foreground">{entry.name}</p>
+					</button>
+				{/each}
+			</div>
+		{/if}
+
+		<!-- Divider -->
+		<div class="my-4 border-t border-border"></div>
+
+		<!-- nevent paste input -->
+		<div class="mb-4">
+			<label class="mb-1 block text-xs text-muted-foreground" for="nevent-input">
+				Add custom theme
+			</label>
+			<input
+				id="nevent-input"
+				type="text"
+				class="w-full rounded-md border border-border bg-secondary px-3 py-2 text-sm text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-primary"
+				placeholder="nevent1..."
+				bind:value={neventInput}
+			/>
+			{#if neventError}
+				<p class="mt-1 text-sm text-destructive">
+					{neventError}
+					<button
+						class="ml-1 text-primary underline"
+						onclick={() => addCustomTheme()}
+					>Retry</button>
+				</p>
+			{/if}
+			<button
+				class="mt-2 w-full rounded-lg bg-primary px-4 py-2 text-sm font-medium text-primary-foreground hover:opacity-80 disabled:opacity-50"
+				disabled={neventLoading || !neventInput.trim()}
+				onclick={addCustomTheme}
+			>
+				{neventLoading ? 'Fetching...' : 'Add Theme'}
+			</button>
+		</div>
+
+		<!-- Action row -->
+		<div class="flex flex-col gap-2">
+			<button
+				class="min-h-[44px] w-full rounded-lg bg-primary px-4 py-2 text-sm font-medium text-primary-foreground hover:opacity-80 disabled:opacity-50"
+				disabled={!selectedEvent || publishing}
+				onclick={applySelectedTheme}
+			>
+				{publishing ? 'Applying...' : 'Apply Theme'}
+			</button>
+			<button
+				class="text-sm text-muted-foreground underline hover:text-foreground"
+				onclick={handleClose}
+			>
+				Keep Current Theme
+			</button>
+		</div>
+
+		<!-- Publish error -->
+		{#if publishError}
+			<p class="mt-2 text-sm text-destructive">{publishError}</p>
+		{/if}
+	</div>
+</div>

--- a/src/lib/nostr/loaders.ts
+++ b/src/lib/nostr/loaders.ts
@@ -19,6 +19,7 @@ export interface NsiteEntry {
 	title?: string;
 	description?: string;
 	versions: NsiteVersion[];
+	sourceEvent?: NostrEvent;
 }
 
 let activePubkey: string | undefined;
@@ -168,7 +169,8 @@ export function getNsitesFromStore(
 				createdAt: root.created_at,
 				title: root.tags.find((t) => t[0] === 'title')?.[1],
 				description: root.tags.find((t) => t[0] === 'description')?.[1],
-				versions: versionsByRef.get(ref ?? siteRef(15128, pubkey)) ?? []
+				versions: versionsByRef.get(ref ?? siteRef(15128, pubkey)) ?? [],
+				sourceEvent: root
 			});
 		}
 	}
@@ -189,7 +191,8 @@ export function getNsitesFromStore(
 				createdAt: event.created_at,
 				title: event.tags.find((t) => t[0] === 'title')?.[1],
 				description: event.tags.find((t) => t[0] === 'description')?.[1],
-				versions: versionsByRef.get(ref ?? siteRef(35128, pubkey, dTag)) ?? []
+				versions: versionsByRef.get(ref ?? siteRef(35128, pubkey, dTag)) ?? [],
+				sourceEvent: event
 			});
 		}
 	}

--- a/src/lib/theme.ts
+++ b/src/lib/theme.ts
@@ -1,4 +1,5 @@
 import type { NostrEvent } from 'nostr-tools';
+import { nip19 } from 'nostr-tools';
 
 // ─── Types ───────────────────────────────────────────────────────────
 
@@ -264,6 +265,53 @@ export function parseActiveProfileTheme(event: NostrEvent): ActiveProfileTheme |
 		titleFont: fonts.title,
 		background: parseBackgroundTag(event.tags)
 	};
+}
+
+/** Parse a kind 36767 shareable theme definition. Returns null if invalid. */
+export function parseThemeDefinition(event: NostrEvent): ActiveProfileTheme | null {
+	if (event.kind !== 36767) return null;
+
+	const colors = parseColorTags(event.tags);
+	if (!colors) return null;
+
+	// Font family sanitization: reject values with characters that could cause CSS injection
+	// Only allow alphanumeric, spaces, hyphens, underscores
+	const fonts = parseFontTags(event.tags);
+	let font = fonts.body;
+	if (font && !/^[A-Za-z0-9 _-]+$/.test(font.family)) {
+		font = undefined;
+	}
+	let titleFont = fonts.title;
+	if (titleFont && !/^[A-Za-z0-9 _-]+$/.test(titleFont.family)) {
+		titleFont = undefined;
+	}
+
+	return {
+		colors,
+		font,
+		titleFont,
+		background: parseBackgroundTag(event.tags)
+	};
+}
+
+/** Decode a nevent/naddr/note bech32 into event id + relay hints. Returns null on failure or unsupported type. */
+export function decodeNeventInput(input: string): { id: string; relays: string[] } | null {
+	try {
+		const decoded = nip19.decode(input.trim());
+		if (decoded.type === 'nevent') {
+			return { id: decoded.data.id, relays: decoded.data.relays ?? [] };
+		}
+		if (decoded.type === 'note') {
+			return { id: decoded.data, relays: [] };
+		}
+		if (decoded.type === 'naddr' && decoded.data.kind === 36767) {
+			// naddr needs special handling: caller fetches by kind+pubkey+d-tag separately
+			return { id: '', relays: decoded.data.relays ?? [] };
+		}
+		return null;
+	} catch {
+		return null;
+	}
 }
 
 // ─── DOM Application ─────────────────────────────────────────────────

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -1,14 +1,19 @@
 <script lang="ts">
 	import { onMount } from 'svelte';
 	import { nip19 } from 'nostr-tools';
-	import { parseNpubFromHostname } from '$lib/nostr/bootstrap';
+	import { parseNpubFromHostname, BOOTSTRAP_RELAYS } from '$lib/nostr/bootstrap';
 	import { subscribe, hydrateFromCache, getNsitesFromStore, type NsiteEntry } from '$lib/nostr/loaders';
-	import { eventStore } from '$lib/nostr/store';
+	import { eventStore, pool } from '$lib/nostr/store';
 	import { parseActiveProfileTheme, applyTheme, clearTheme } from '$lib/theme';
+	import { getOutboxes } from 'applesauce-core/helpers/mailboxes';
 	import type { ProfileContent } from 'applesauce-core/helpers/profile';
 	import ProfileCard from '$lib/components/ProfileCard.svelte';
 	import NsiteList from '$lib/components/NsiteList.svelte';
 	import ErrorMessage from '$lib/components/ErrorMessage.svelte';
+	import { restoreSession, logout, isOwner, getSigner } from '$lib/auth.svelte';
+	import LoginModal from '$lib/components/LoginModal.svelte';
+	import OwnerBadge from '$lib/components/OwnerBadge.svelte';
+	import ThemePicker from '$lib/components/ThemePicker.svelte';
 
 	let error = $state<string | null>(null);
 	let profile = $state<ProfileContent | undefined>(undefined);
@@ -16,6 +21,9 @@
 	let npub = $state('');
 	let host = $state('');
 	let pubkey = $state('');
+	let showLoginModal = $state(false);
+	let showThemePicker = $state(false);
+	let writeRelays = $state<string[]>([]);
 
 	onMount(() => {
 		import('@nsite/stealthis');
@@ -28,20 +36,25 @@
 			return;
 		}
 
+		restoreSession();
+
 		const unsubscribe = subscribe(parsed);
 		const extraSubs: Array<{ unsubscribe(): void }> = [];
 		let profileSub: { unsubscribe(): void } | null = null;
 		let nsiteSub: { unsubscribe(): void } | null = null;
 		let themeSub: { unsubscribe(): void } | null = null;
+		let relaySub: { unsubscribe(): void } | null = null;
 		let boundPubkey: string | null = null;
 
 		function cleanupAuthorSubscriptions() {
 			profileSub?.unsubscribe();
 			nsiteSub?.unsubscribe();
 			themeSub?.unsubscribe();
+			relaySub?.unsubscribe();
 			profileSub = null;
 			nsiteSub = null;
 			themeSub = null;
+			relaySub = null;
 		}
 
 		function bindAuthor(nextPubkey: string) {
@@ -77,6 +90,15 @@
 					if (theme) applyTheme(theme);
 				});
 
+			// Reactively read kind 10002 relay list to compute writeRelays
+			relaySub = eventStore
+				.filters({ kinds: [10002], authors: [nextPubkey] })
+				.subscribe((event) => {
+					if (!event) return;
+					const relays = getOutboxes(event);
+					writeRelays = relays.length > 0 ? relays : BOOTSTRAP_RELAYS;
+				});
+
 			nsites = getNsitesFromStore(nextPubkey, { includeRoot: true });
 		}
 
@@ -106,17 +128,63 @@
 	<title>{profile?.display_name || profile?.name || 'nsite'}</title>
 </svelte:head>
 
-<div class="min-h-screen text-foreground">
+<div class="min-h-screen bg-background text-foreground">
 	<div class="mx-auto max-w-2xl py-8">
+		{#if showLoginModal}
+			<LoginModal onClose={() => (showLoginModal = false)} />
+		{/if}
+		{#if showThemePicker}
+			<ThemePicker
+				signer={getSigner()!}
+				{pool}
+				{pubkey}
+				{writeRelays}
+				onclose={() => (showThemePicker = false)}
+			/>
+		{/if}
 		{#if error && !profile}
 			<ErrorMessage message={error} />
 		{:else}
 			<div class="overflow-hidden rounded-xl border border-border bg-background">
+				{#if isOwner()}
+					<OwnerBadge ontheme={() => (showThemePicker = true)} />
+				{/if}
 				<ProfileCard {profile} {npub} />
-				<NsiteList {nsites} {host} {pubkey} />
+				<NsiteList
+					{nsites}
+					{host}
+					{pubkey}
+					isOwner={isOwner()}
+					signer={getSigner() ?? undefined}
+					{pool}
+					{writeRelays}
+				/>
 			</div>
-			<div class="mt-6 flex justify-center">
+			<div class="mt-6 flex items-center justify-center gap-4">
 				<nsite-deploy label="Steal this nsite"></nsite-deploy>
+				<a
+					href="https://github.com/sandwichfarm/npub-home"
+					target="_blank"
+					rel="noopener noreferrer"
+					class="text-sm text-muted-foreground hover:text-foreground"
+				>GitHub</a>
+				{#if isOwner()}
+					<span class="flex items-center gap-1">
+						<button
+							class="text-sm text-muted-foreground underline hover:text-foreground"
+							onclick={logout}
+						>Logout</button>
+						<span
+							class="inline-block h-2 w-2 rounded-full bg-primary"
+							aria-label="Owner"
+						></span>
+					</span>
+				{:else}
+					<button
+						class="text-sm text-muted-foreground hover:text-foreground"
+						onclick={() => (showLoginModal = true)}
+					>Login</button>
+				{/if}
 			</div>
 		{/if}
 	</div>

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,21 @@
+import { defineConfig } from 'vitest/config';
+import { svelte } from '@sveltejs/vite-plugin-svelte';
+import path from 'path';
+
+export default defineConfig({
+	plugins: [svelte({ hot: false })],
+	resolve: {
+		// 'browser' condition is required so Svelte resolves to the client bundle
+		// (index-client.js) rather than the server bundle (index-server.js) in jsdom tests.
+		conditions: ['browser'],
+		alias: {
+			$lib: path.resolve(__dirname, 'src/lib'),
+		},
+	},
+	test: {
+		environment: 'jsdom',
+		include: ['src/**/*.test.ts'],
+		globals: true,
+		setupFiles: ['src/lib/__tests__/setup.ts'],
+	},
+});


### PR DESCRIPTION
## Summary

- **Auth:** NIP-07 browser extension + NIP-46 remote signer login (bunker URI paste, nostrconnect:// QR code, editable relay field). Owner detection, session persistence, logout.
- **Theme Picker:** Modal with 8 curated kind 36767 themes, color swatch previews, live preview via `applyTheme()`, nevent/naddr paste for custom themes, publish as kind 16767. Props-only extractable component.
- **Nsite Management:** Inline edit name/description (republish via `EventFactory.modify`), NIP-09 deletion with best-effort warning. Preserves upstream snapshot/versions UI.
- **UI Polish:** GitHub repo link in footer, `bg-background` fix for default dark theme.

## Key files

| File | Purpose |
|------|---------|
| `src/lib/auth.svelte.ts` | Svelte 5 reactive auth singleton (NIP-07 + NIP-46) |
| `src/lib/components/LoginModal.svelte` | Tabbed login (Extension + Remote Signer tabs) |
| `src/lib/components/ThemePicker.svelte` | Props-only theme picker (8 curated themes) |
| `src/lib/components/NsiteList.svelte` | Extended with inline edit/delete management |
| `src/lib/components/OwnerBadge.svelte` | Owner indicator with Theme + Logout |
| `src/lib/theme.ts` | Added `parseThemeDefinition()` + `decodeNeventInput()` |
| `vitest.config.ts` | Test framework setup |

## Test plan

- [x] 63 unit tests passing (`pnpm vitest run`)
- [x] TypeScript clean (`pnpm check` — 0 errors)
- [x] Production build clean (`pnpm build`)
- [x] Browser: NIP-07 login with extension (Alby/nos2x)
- [x] Browser: NIP-46 login with bunker URI paste
- [x] Browser: NIP-46 QR code scan + relay field live update
- [x] Browser: Theme picker — curated themes load, live preview, publish
- [ ] Browser: Edit nsite name/description, save publishes updated event
- [ ] Browser: Delete nsite with best-effort warning, publishes kind 5
- [ ] Browser: Session survives page reload
- [x] Browser: Logout hides all management UI
- [ ] Browser: Snapshot/versions UI still works for visitors